### PR TITLE
Add index/collection:dump/restore

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,8 @@
     "indent": "off",
     "no-await-in-loop": "off",
     "node/no-deprecated-api": "off",
-    "unicorn/no-abusive-eslint-disable": "off"
+    "unicorn/no-abusive-eslint-disable": "off",
+    "brace-style": "off",
+    "operator-linebreak": "off"
   }
 }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ npm install -g kourou
 $ kourou COMMAND
 running command...
 $ kourou (-v|--version|version)
-kourou/0.3.0 linux-x64 node-v12.13.1
+kourou/0.4.0 linux-x64 node-v12.13.1
 $ kourou --help [COMMAND]
 USAGE
   $ kourou COMMAND
@@ -86,7 +86,7 @@ OPTIONS
   --username=username            [default: anonymous] Kuzzle user
 ```
 
-_See code: [src/commands/api-key/create.ts](https://github.com/kuzzleio/kourou/blob/v0.3.0/src/commands/api-key/create.ts)_
+_See code: [src/commands/api-key/create.ts](https://github.com/kuzzleio/kourou/blob/v0.4.0/src/commands/api-key/create.ts)_
 
 ## `kourou api-key:delete`
 
@@ -107,7 +107,7 @@ OPTIONS
   --username=username  [default: anonymous] Kuzzle user
 ```
 
-_See code: [src/commands/api-key/delete.ts](https://github.com/kuzzleio/kourou/blob/v0.3.0/src/commands/api-key/delete.ts)_
+_See code: [src/commands/api-key/delete.ts](https://github.com/kuzzleio/kourou/blob/v0.4.0/src/commands/api-key/delete.ts)_
 
 ## `kourou api-key:search`
 
@@ -128,7 +128,7 @@ OPTIONS
   --username=username  [default: anonymous] Kuzzle user
 ```
 
-_See code: [src/commands/api-key/search.ts](https://github.com/kuzzleio/kourou/blob/v0.3.0/src/commands/api-key/search.ts)_
+_See code: [src/commands/api-key/search.ts](https://github.com/kuzzleio/kourou/blob/v0.4.0/src/commands/api-key/search.ts)_
 
 ## `kourou collection:dump INDEX COLLECTION`
 
@@ -153,7 +153,7 @@ OPTIONS
   --username=username      [default: anonymous] Kuzzle user
 ```
 
-_See code: [src/commands/collection/dump.ts](https://github.com/kuzzleio/kourou/blob/v0.3.0/src/commands/collection/dump.ts)_
+_See code: [src/commands/collection/dump.ts](https://github.com/kuzzleio/kourou/blob/v0.4.0/src/commands/collection/dump.ts)_
 
 ## `kourou collection:restore PATH`
 
@@ -178,7 +178,7 @@ OPTIONS
   --username=username      [default: anonymous] Kuzzle user
 ```
 
-_See code: [src/commands/collection/restore.ts](https://github.com/kuzzleio/kourou/blob/v0.3.0/src/commands/collection/restore.ts)_
+_See code: [src/commands/collection/restore.ts](https://github.com/kuzzleio/kourou/blob/v0.4.0/src/commands/collection/restore.ts)_
 
 ## `kourou document:get INDEX COLLECTION ID`
 
@@ -202,7 +202,7 @@ OPTIONS
   --username=username  [default: anonymous] Kuzzle user
 ```
 
-_See code: [src/commands/document/get.ts](https://github.com/kuzzleio/kourou/blob/v0.3.0/src/commands/document/get.ts)_
+_See code: [src/commands/document/get.ts](https://github.com/kuzzleio/kourou/blob/v0.4.0/src/commands/document/get.ts)_
 
 ## `kourou help [COMMAND]`
 
@@ -232,7 +232,7 @@ OPTIONS
   -i, --instance=instance  Kuzzle instance name
 ```
 
-_See code: [src/commands/instance/logs.ts](https://github.com/kuzzleio/kourou/blob/v0.3.0/src/commands/instance/logs.ts)_
+_See code: [src/commands/instance/logs.ts](https://github.com/kuzzleio/kourou/blob/v0.4.0/src/commands/instance/logs.ts)_
 
 ## `kourou instance:spawn`
 
@@ -248,7 +248,7 @@ OPTIONS
   --help                 show CLI help
 ```
 
-_See code: [src/commands/instance/spawn.ts](https://github.com/kuzzleio/kourou/blob/v0.3.0/src/commands/instance/spawn.ts)_
+_See code: [src/commands/instance/spawn.ts](https://github.com/kuzzleio/kourou/blob/v0.4.0/src/commands/instance/spawn.ts)_
 <!-- commandsstop -->
 
 # Where does this weird name comes from?

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ $ npm install -g kourou
 $ kourou COMMAND
 running command...
 $ kourou (-v|--version|version)
-kourou/0.4.0 linux-x64 node-v12.13.1
+kourou/0.5.0 linux-x64 node-v12.13.1
 $ kourou --help [COMMAND]
 USAGE
   $ kourou COMMAND
@@ -62,6 +62,8 @@ By environment variables:
 * [`kourou collection:restore PATH`](#kourou-collectionrestore-path)
 * [`kourou document:get INDEX COLLECTION ID`](#kourou-documentget-index-collection-id)
 * [`kourou help [COMMAND]`](#kourou-help-command)
+* [`kourou index:dump INDEX`](#kourou-indexdump-index)
+* [`kourou index:restore PATH`](#kourou-indexrestore-path)
 * [`kourou instance:logs`](#kourou-instancelogs)
 * [`kourou instance:spawn`](#kourou-instancespawn)
 
@@ -86,7 +88,7 @@ OPTIONS
   --username=username            [default: anonymous] Kuzzle user
 ```
 
-_See code: [src/commands/api-key/create.ts](https://github.com/kuzzleio/kourou/blob/v0.4.0/src/commands/api-key/create.ts)_
+_See code: [src/commands/api-key/create.ts](https://github.com/kuzzleio/kourou/blob/v0.5.0/src/commands/api-key/create.ts)_
 
 ## `kourou api-key:delete`
 
@@ -107,7 +109,7 @@ OPTIONS
   --username=username  [default: anonymous] Kuzzle user
 ```
 
-_See code: [src/commands/api-key/delete.ts](https://github.com/kuzzleio/kourou/blob/v0.4.0/src/commands/api-key/delete.ts)_
+_See code: [src/commands/api-key/delete.ts](https://github.com/kuzzleio/kourou/blob/v0.5.0/src/commands/api-key/delete.ts)_
 
 ## `kourou api-key:search`
 
@@ -128,7 +130,7 @@ OPTIONS
   --username=username  [default: anonymous] Kuzzle user
 ```
 
-_See code: [src/commands/api-key/search.ts](https://github.com/kuzzleio/kourou/blob/v0.4.0/src/commands/api-key/search.ts)_
+_See code: [src/commands/api-key/search.ts](https://github.com/kuzzleio/kourou/blob/v0.5.0/src/commands/api-key/search.ts)_
 
 ## `kourou collection:dump INDEX COLLECTION`
 
@@ -153,7 +155,7 @@ OPTIONS
   --username=username      [default: anonymous] Kuzzle user
 ```
 
-_See code: [src/commands/collection/dump.ts](https://github.com/kuzzleio/kourou/blob/v0.4.0/src/commands/collection/dump.ts)_
+_See code: [src/commands/collection/dump.ts](https://github.com/kuzzleio/kourou/blob/v0.5.0/src/commands/collection/dump.ts)_
 
 ## `kourou collection:restore PATH`
 
@@ -178,7 +180,7 @@ OPTIONS
   --username=username      [default: anonymous] Kuzzle user
 ```
 
-_See code: [src/commands/collection/restore.ts](https://github.com/kuzzleio/kourou/blob/v0.4.0/src/commands/collection/restore.ts)_
+_See code: [src/commands/collection/restore.ts](https://github.com/kuzzleio/kourou/blob/v0.5.0/src/commands/collection/restore.ts)_
 
 ## `kourou document:get INDEX COLLECTION ID`
 
@@ -202,7 +204,7 @@ OPTIONS
   --username=username  [default: anonymous] Kuzzle user
 ```
 
-_See code: [src/commands/document/get.ts](https://github.com/kuzzleio/kourou/blob/v0.4.0/src/commands/document/get.ts)_
+_See code: [src/commands/document/get.ts](https://github.com/kuzzleio/kourou/blob/v0.5.0/src/commands/document/get.ts)_
 
 ## `kourou help [COMMAND]`
 
@@ -221,6 +223,54 @@ OPTIONS
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.2.3/src/commands/help.ts)_
 
+## `kourou index:dump INDEX`
+
+Dump an entire index content (JSONL format)
+
+```
+USAGE
+  $ kourou index:dump INDEX
+
+ARGUMENTS
+  INDEX  Index name
+
+OPTIONS
+  -h, --host=host          [default: localhost] Kuzzle server host
+  -p, --port=port          [default: 7512] Kuzzle server port
+  --batch-size=batch-size  [default: 5000] Maximum batch size (see limits.documentsFetchCount config)
+  --help                   show CLI help
+  --password=password      Kuzzle user password
+  --path=path              Dump directory (default: index name)
+  --ssl                    Use SSL to connect to Kuzzle
+  --username=username      [default: anonymous] Kuzzle user
+```
+
+_See code: [src/commands/index/dump.ts](https://github.com/kuzzleio/kourou/blob/v0.5.0/src/commands/index/dump.ts)_
+
+## `kourou index:restore PATH`
+
+Restore the content of a previously dumped index
+
+```
+USAGE
+  $ kourou index:restore PATH
+
+ARGUMENTS
+  PATH  Dump directory or file
+
+OPTIONS
+  -h, --host=host          [default: localhost] Kuzzle server host
+  -p, --port=port          [default: 7512] Kuzzle server port
+  --batch-size=batch-size  [default: 5000] Maximum batch size (see limits.documentsFetchCount config)
+  --help                   show CLI help
+  --index=index            If set, override the index destination name
+  --password=password      Kuzzle user password
+  --ssl                    Use SSL to connect to Kuzzle
+  --username=username      [default: anonymous] Kuzzle user
+```
+
+_See code: [src/commands/index/restore.ts](https://github.com/kuzzleio/kourou/blob/v0.5.0/src/commands/index/restore.ts)_
+
 ## `kourou instance:logs`
 
 ```
@@ -232,7 +282,7 @@ OPTIONS
   -i, --instance=instance  Kuzzle instance name
 ```
 
-_See code: [src/commands/instance/logs.ts](https://github.com/kuzzleio/kourou/blob/v0.4.0/src/commands/instance/logs.ts)_
+_See code: [src/commands/instance/logs.ts](https://github.com/kuzzleio/kourou/blob/v0.5.0/src/commands/instance/logs.ts)_
 
 ## `kourou instance:spawn`
 
@@ -248,7 +298,7 @@ OPTIONS
   --help                 show CLI help
 ```
 
-_See code: [src/commands/instance/spawn.ts](https://github.com/kuzzleio/kourou/blob/v0.4.0/src/commands/instance/spawn.ts)_
+_See code: [src/commands/instance/spawn.ts](https://github.com/kuzzleio/kourou/blob/v0.5.0/src/commands/instance/spawn.ts)_
 <!-- commandsstop -->
 
 # Where does this weird name comes from?

--- a/README.md
+++ b/README.md
@@ -58,6 +58,8 @@ By environment variables:
 * [`kourou api-key:create`](#kourou-api-keycreate)
 * [`kourou api-key:delete`](#kourou-api-keydelete)
 * [`kourou api-key:search`](#kourou-api-keysearch)
+* [`kourou collection:dump INDEX COLLECTION`](#kourou-collectiondump-index-collection)
+* [`kourou collection:restore PATH`](#kourou-collectionrestore-path)
 * [`kourou document:get INDEX COLLECTION ID`](#kourou-documentget-index-collection-id)
 * [`kourou help [COMMAND]`](#kourou-help-command)
 * [`kourou instance:logs`](#kourou-instancelogs)
@@ -127,6 +129,56 @@ OPTIONS
 ```
 
 _See code: [src/commands/api-key/search.ts](https://github.com/kuzzleio/kourou/blob/v0.3.0/src/commands/api-key/search.ts)_
+
+## `kourou collection:dump INDEX COLLECTION`
+
+Dump an entire collection content (JSONL format)
+
+```
+USAGE
+  $ kourou collection:dump INDEX COLLECTION
+
+ARGUMENTS
+  INDEX       Index name
+  COLLECTION  Collection name
+
+OPTIONS
+  -h, --host=host          [default: localhost] Kuzzle server host
+  -p, --port=port          [default: 7512] Kuzzle server port
+  --batch-size=batch-size  [default: 5000] Maximum batch size (see limits.documentsFetchCount config)
+  --help                   show CLI help
+  --password=password      Kuzzle user password
+  --path=path              Dump directory (default: index name)
+  --ssl                    Use SSL to connect to Kuzzle
+  --username=username      [default: anonymous] Kuzzle user
+```
+
+_See code: [src/commands/collection/dump.ts](https://github.com/kuzzleio/kourou/blob/v0.3.0/src/commands/collection/dump.ts)_
+
+## `kourou collection:restore PATH`
+
+Restore the content of a previously dumped collection
+
+```
+USAGE
+  $ kourou collection:restore PATH
+
+ARGUMENTS
+  PATH  Dump file path
+
+OPTIONS
+  -h, --host=host          [default: localhost] Kuzzle server host
+  -p, --port=port          [default: 7512] Kuzzle server port
+  --batch-size=batch-size  [default: 5000] Maximum batch size (see limits.documentsFetchCount config)
+  --collection=collection  If set, override the collection destination name
+  --help                   show CLI help
+  --index=index            If set, override the index destination name
+  --password=password      Kuzzle user password
+  --ssl                    Use SSL to connect to Kuzzle
+  --username=username      [default: anonymous] Kuzzle user
+```
+
+_See code: [src/commands/collection/restore.ts](https://github.com/kuzzleio/kourou/blob/v0.3.0/src/commands/collection/restore.ts)_
 
 ## `kourou document:get INDEX COLLECTION ID`
 

--- a/features/Collection.feature
+++ b/features/Collection.feature
@@ -1,0 +1,22 @@
+Feature: Collection Commands
+
+  @mappings
+  Scenario: Dump and restore a collection
+    Given an existing collection "nyc-open-data":"yellow-taxi"
+    And I "create" the following documents:
+      | _id               | body                              |
+      | "chuon-chuon-kim" | { "city": "hcmc", "district": 1 } |
+      | "the-hive"        | { "city": "hcmc", "district": 2 } |
+    When I run the command "collection:dump" with args:
+      | "nyc-open-data" |
+      | "yellow-taxi"   |
+    And I truncate the collection "nyc-open-data":"yellow-taxi"
+    And I run the command "collection:restore" with args:
+      | "nyc-open-data/collection-yellow-taxi.jsonl" |
+    Then The document "chuon-chuon-kim" content match:
+      | city     | "hcmc" |
+      | district | 1      |
+    And The document "the-hive" content match:
+      | city     | "hcmc" |
+      | district | 2      |
+

--- a/features/Index.feature
+++ b/features/Index.feature
@@ -1,0 +1,34 @@
+Feature: Index Commands
+
+  @mappings
+  Scenario: Dump and restore an index
+    Given an existing collection "nyc-open-data":"yellow-taxi"
+    And I "create" the following documents:
+      | _id               | body                              |
+      | "chuon-chuon-kim" | { "city": "hcmc", "district": 1 } |
+      | "the-hive"        | { "city": "hcmc", "district": 2 } |
+    And a collection "nyc-open-data":"green-taxi"
+    And I "create" the following documents:
+      | _id                | body                              |
+      | "chuon-chuon-kim2" | { "city": "hcmc", "district": 1 } |
+      | "the-hive2"        | { "city": "hcmc", "district": 2 } |
+    When I run the command "index:dump" with args:
+      | "nyc-open-data" |
+    And I truncate the collection "nyc-open-data":"yellow-taxi"
+    And I truncate the collection "nyc-open-data":"green-taxi"
+    And I run the command "index:restore" with args:
+      | "nyc-open-data" |
+    Then The document "chuon-chuon-kim2" content match:
+      | city     | "hcmc" |
+      | district | 1      |
+    And The document "the-hive2" content match:
+      | city     | "hcmc" |
+      | district | 2      |
+    And an existing collection "nyc-open-data":"yellow-taxi"
+    Then The document "chuon-chuon-kim" content match:
+      | city     | "hcmc" |
+      | district | 1      |
+    And The document "the-hive" content match:
+      | city     | "hcmc" |
+      | district | 2      |
+

--- a/features/step_definitions/common/collection-steps.js
+++ b/features/step_definitions/common/collection-steps.js
@@ -48,3 +48,7 @@ Then('I get mappings of collection {string}:{string}', async function (index, co
 Then('I refresh the collection', function () {
   return this.sdk.collection.refresh(this.props.index, this.props.collection);
 });
+
+Then('I truncate the collection {string}:{string}', function (index, collection) {
+  return this.sdk.collection.truncate(index, collection);
+});

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kourou",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kourou",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -5406,8 +5406,7 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-      "dev": true
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
     },
     "json5": {
       "version": "2.1.1",
@@ -6240,6 +6239,24 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/natural-orderby/-/natural-orderby-2.0.3.tgz",
       "integrity": "sha512-p7KTHxU0CUrcOXe62Zfrb5Z13nLvPhSWR/so3kFulUQU0sgUll2Z0LwpsLN351eOOD+hRGu/F1g+6xDfPeD++Q=="
+    },
+    "ndjson": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/ndjson/-/ndjson-1.5.0.tgz",
+      "integrity": "sha1-rmA7NrE0vOw0e0UkIrC/mNWDLsg=",
+      "requires": {
+        "json-stringify-safe": "^5.0.1",
+        "minimist": "^1.2.0",
+        "split2": "^2.1.0",
+        "through2": "^2.0.3"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+        }
+      }
     },
     "neo-async": {
       "version": "2.6.1",
@@ -8032,6 +8049,14 @@
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "requires": {
         "extend-shallow": "^3.0.0"
+      }
+    },
+    "split2": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/split2/-/split2-2.2.0.tgz",
+      "integrity": "sha512-RAb22TG39LhI31MbreBgIuKiIKhVsawfTgEGqKHTK87aG+ul/PB8Sqoi3I7kVdRWiCfrKxK3uo4/YUkpNvhPbw==",
+      "requires": {
+        "through2": "^2.0.2"
       }
     },
     "sprintf-js": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kourou",
   "description": "The CLI that helps you manage your Kuzzle instances",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": "The Kuzzle Team <support@kuzzle.io>",
   "bin": {
     "kourou": "./bin/run"

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "postpack": "rm -f oclif.manifest.json",
     "prepack": "rm -rf lib && tsc -b && oclif-dev manifest && oclif-dev readme",
     "version": "oclif-dev readme && git add README.md",
-    "test:lint": "eslint . --fix --ext .ts --config .eslintrc",
+    "test:lint": "eslint . --ext .ts --config .eslintrc",
     "test:functional": "npm run test:functional:stdout && npm run test:functional:cucumber",
     "test:functional:stdout": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\"",
     "test:functional:cucumber": "./node_modules/.bin/cucumber-js"

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "inquirer": "^7.0.3",
     "kuzzle-sdk": "^7.0.1",
     "listr": "^0.14.3",
+    "ndjson": "^1.5.0",
     "node-emoji": "^1.10.0",
     "tslib": "^1.10.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kourou",
   "description": "The CLI that helps you manage your Kuzzle instances",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "author": "The Kuzzle Team <support@kuzzle.io>",
   "bin": {
     "kourou": "./bin/run"

--- a/src/commands/collection/dump.ts
+++ b/src/commands/collection/dump.ts
@@ -1,0 +1,53 @@
+import { flags } from '@oclif/command'
+import { Kommand, printCliName } from '../../common'
+import { kuzzleFlags, KuzzleSDK } from '../../kuzzle'
+import dumpCollection from '../../support/dump-collection'
+import * as fs from 'fs'
+import chalk from 'chalk'
+
+export default class CollectionDump extends Kommand {
+  static description = 'Dump an entire collection content (JSONL format)'
+
+  static flags = {
+    help: flags.help({}),
+    path: flags.string({
+      description: 'Dump directory (default: index name)',
+    }),
+    'batch-size': flags.string({
+      description: 'Maximum batch size (see limits.documentsFetchCount config)',
+      default: '5000'
+    }),
+    ...kuzzleFlags,
+  }
+
+  static args = [
+    { name: 'index', description: 'Index name', required: true },
+    { name: 'collection', description: 'Collection name', required: true },
+  ]
+
+  async run() {
+    this.log('')
+    this.log(`${printCliName()} - ${CollectionDump.description}`)
+    this.log('')
+
+    const { args, flags: userFlags } = this.parse(CollectionDump)
+
+    const path = userFlags.path || args.index
+
+    const sdk = new KuzzleSDK(userFlags)
+    await sdk.init()
+
+    this.log(`Dumping collection "${args.index}:${args.collection}" in ${path}/ ...`)
+
+    fs.mkdirSync(path, { recursive: true })
+
+    await dumpCollection(
+      sdk,
+      args.index,
+      args.collection,
+      Number(userFlags['batch-size']),
+      path)
+
+    this.log(chalk.green(`[✔] Collection ${args.index}:${collection.name} dumped`))
+  }
+}

--- a/src/commands/collection/dump.ts
+++ b/src/commands/collection/dump.ts
@@ -48,6 +48,6 @@ export default class CollectionDump extends Kommand {
       Number(userFlags['batch-size']),
       path)
 
-    this.log(chalk.green(`[✔] Collection ${args.index}:${collection.name} dumped`))
+    this.log(chalk.green(`[✔] Collection ${args.index}:${args.collection.name} dumped`))
   }
 }

--- a/src/commands/collection/restore.ts
+++ b/src/commands/collection/restore.ts
@@ -1,0 +1,59 @@
+import { flags } from '@oclif/command'
+import { Kommand, printCliName } from '../../common'
+import { kuzzleFlags, KuzzleSDK } from '../../kuzzle'
+import chalk from 'chalk'
+import restoreCollection from '../../support/restore-collection'
+
+export default class CollectionRestore extends Kommand {
+  static description = 'Restore the content of a previously dumped collection'
+
+  static flags = {
+    help: flags.help({}),
+    'batch-size': flags.string({
+      description: 'Maximum batch size (see limits.documentsFetchCount config)',
+      default: '5000'
+    }),
+    index: flags.string({
+      description: 'If set, override the index destination name',
+    }),
+    collection: flags.string({
+      description: 'If set, override the collection destination name',
+    }),
+    ...kuzzleFlags,
+  }
+
+  static args = [
+    { name: 'path', description: 'Dump file path', required: true },
+  ]
+
+  async run() {
+    this.log('')
+    this.log(`${printCliName()} - ${CollectionRestore.description}`)
+    this.log('')
+
+    const { args, flags: userFlags } = this.parse(CollectionRestore)
+
+    const index = userFlags.index
+    const collection = userFlags.collection
+
+    const sdk = new KuzzleSDK(userFlags)
+
+    await sdk.init()
+
+    this.log(chalk.green(`[✔] Start importing dump from ${args.path}`))
+
+    try {
+      await restoreCollection(
+        sdk,
+        this.log.bind(this),
+        Number(userFlags['batch-size']),
+        args.path,
+        index,
+        collection)
+
+      this.log(chalk.green(`[✔] Dump file ${args.path} imported`))
+    } catch (error) {
+      this.log(chalk.red(`[ℹ] Error while importing: ${error.message}`))
+    }
+  }
+}

--- a/src/commands/index/dump.ts
+++ b/src/commands/index/dump.ts
@@ -1,0 +1,58 @@
+import { flags } from '@oclif/command'
+import { Kommand, printCliName } from '../../common'
+import { kuzzleFlags, KuzzleSDK } from '../../kuzzle'
+import dumpCollection from '../../support/dumpCollection'
+import * as fs from 'fs'
+import chalk from 'chalk'
+
+export default class IndexDump extends Kommand {
+  static description = 'Dump an entire index content (JSONL format)'
+
+  static flags = {
+    help: flags.help({}),
+    path: flags.string({
+      description: 'Dump directory (default: index name)',
+    }),
+    'batch-size': flags.string({
+      description: 'Maximum batch size (see limits.documentsFetchCount config)',
+      default: '5000'
+    }),
+    ...kuzzleFlags,
+  }
+
+  static args = [
+    { name: 'index', description: 'Index name', required: true },
+  ]
+
+  async run() {
+    this.log('')
+    this.log(`${printCliName()} - ${IndexDump.description}`)
+    this.log('')
+
+    const { args, flags: userFlags } = this.parse(IndexDump)
+
+    const path = userFlags.path || args.index
+
+    const sdk = new KuzzleSDK(userFlags)
+    await sdk.init()
+
+    this.log(`Dumping index "${args.index}" in ${path}/ ...`)
+
+    fs.mkdirSync(path, { recursive: true })
+
+    const { collections } = await sdk.collection.list(args.index)
+
+    for (const collection of collections) {
+      if (collection.type !== 'realtime') {
+        await dumpCollection(
+          sdk,
+          args.index,
+          collection.name,
+          Number(userFlags['batch-size']),
+          path)
+
+        this.log(chalk.green(`[✔] Collection ${args.index}:${collection.name} dumped`))
+      }
+    }
+  }
+}

--- a/src/commands/index/dump.ts
+++ b/src/commands/index/dump.ts
@@ -1,7 +1,7 @@
 import { flags } from '@oclif/command'
 import { Kommand, printCliName } from '../../common'
 import { kuzzleFlags, KuzzleSDK } from '../../kuzzle'
-import dumpCollection from '../../support/dumpCollection'
+import dumpCollection from '../../support/dump-collection'
 import * as fs from 'fs'
 import chalk from 'chalk'
 

--- a/src/commands/index/restore.ts
+++ b/src/commands/index/restore.ts
@@ -3,7 +3,7 @@ import { Kommand, printCliName } from '../../common'
 import { kuzzleFlags, KuzzleSDK } from '../../kuzzle'
 import * as fs from 'fs'
 import chalk from 'chalk'
-import restoreCollection from '../../support/restoreCollection'
+import restoreCollection from '../../support/restore-collection'
 
 export default class IndexRestore extends Kommand {
   static description = 'Restore the content of a previously dumped index'

--- a/src/commands/index/restore.ts
+++ b/src/commands/index/restore.ts
@@ -1,0 +1,67 @@
+import { flags } from '@oclif/command'
+import { Kommand, printCliName } from '../../common'
+import { kuzzleFlags, KuzzleSDK } from '../../kuzzle'
+import * as fs from 'fs'
+import chalk from 'chalk'
+import restoreCollection from '../../support/restoreCollection'
+
+export default class IndexRestore extends Kommand {
+  static description = 'Restore the content of a previously dumped index'
+
+  static flags = {
+    help: flags.help({}),
+    'batch-size': flags.string({
+      description: 'Maximum batch size (see limits.documentsFetchCount config)',
+      default: '5000'
+    }),
+    index: flags.string({
+      description: 'If set, override the index destination name',
+    }),
+    ...kuzzleFlags,
+  }
+
+  static args = [
+    { name: 'path', description: 'Dump directory or file', required: true },
+  ]
+
+  async run() {
+    this.log('')
+    this.log(`${printCliName()} - ${IndexRestore.description}`)
+    this.log('')
+
+    const { args, flags: userFlags } = this.parse(IndexRestore)
+
+    const index = userFlags.index
+
+    const sdk = new KuzzleSDK(userFlags)
+
+    await sdk.init()
+
+    if (index) {
+      this.log(chalk.green(`[✔] Start importing dump from ${args.path} in index ${index}`))
+    } else {
+      this.log(chalk.green(`[✔] Start importing dump from ${args.path} in same index`))
+    }
+
+    const dumpFiles = fs.readdirSync(args.path).map(f => `${args.path}/${f}`)
+
+    try {
+      for (const dumpFile of dumpFiles) {
+        await restoreCollection(
+          sdk,
+          this.log.bind(this),
+          Number(userFlags['batch-size']),
+          dumpFile,
+          index)
+
+        if (index) {
+          this.log(chalk.green(`[✔] Dump file ${dumpFile} imported in index ${index}`))
+        } else {
+          this.log(chalk.green(`[✔] Dump file ${dumpFile} imported`))
+        }
+      }
+    } catch (error) {
+      this.log(chalk.red(`[ℹ] Error while importing: ${error.message}`))
+    }
+  }
+}

--- a/src/commands/instance/logs.ts
+++ b/src/commands/instance/logs.ts
@@ -65,9 +65,9 @@ export class InstanceLogs extends Command {
     const containersList: string[] = containersListProcess.stdout.replace(/"/g, '').split('\n')
 
     return containersList.filter(containerName =>
-      (containerName.includes('kuzzle')
-        && !containerName.includes('redis')
-        && !containerName.includes('elasticsearch')))
+      (containerName.includes('kuzzle') &&
+        !containerName.includes('redis') &&
+        !containerName.includes('elasticsearch')))
   }
 }
 

--- a/src/commands/instance/logs.ts
+++ b/src/commands/instance/logs.ts
@@ -65,9 +65,9 @@ export class InstanceLogs extends Command {
     const containersList: string[] = containersListProcess.stdout.replace(/"/g, '').split('\n')
 
     return containersList.filter(containerName =>
-      (containerName.includes('kuzzle') &&
-        !containerName.includes('redis') &&
-        !containerName.includes('elasticsearch')))
+      (containerName.includes('kuzzle')
+        && !containerName.includes('redis')
+        && !containerName.includes('elasticsearch')))
   }
 }
 

--- a/src/kuzzle.ts
+++ b/src/kuzzle.ts
@@ -70,4 +70,8 @@ export class KuzzleSDK {
   get document() {
     return this.sdk.document
   }
+
+  get collection() {
+    return this.sdk.collection
+  }
 }

--- a/src/support/dump-collection.ts
+++ b/src/support/dump-collection.ts
@@ -1,5 +1,7 @@
-import * as ndjson from 'ndjson'
 import * as fs from 'fs'
+
+// tslint:disable-next-line
+const ndjson = require('ndjson')
 
 async function dumpCollection(sdk: any, index: string, collection: string, batchSize: number, path: string) {
   const filename = `${path}/collection-${collection}.jsonl`

--- a/src/support/dump-collection.ts
+++ b/src/support/dump-collection.ts
@@ -1,0 +1,52 @@
+import * as ndjson from 'ndjson'
+import * as fs from 'fs'
+
+async function dumpCollection(sdk: any, index: string, collection: string, batchSize: number, path: string) {
+  const filename = `${path}/collection-${collection}.jsonl`
+  const writeStream = fs.createWriteStream(filename)
+  const waitWrite = new Promise(resolve => writeStream.on('finish', resolve))
+  const ndjsonStream = ndjson.serialize()
+  const options = {
+    scroll: '10m',
+    size: batchSize
+  }
+
+  writeStream.on('error', error => {
+    throw error
+  })
+
+  ndjsonStream.on('data', (line: string) => writeStream.write(line))
+
+  await new Promise(resolve => {
+    if (ndjsonStream.write({ index: index, collection })) {
+      resolve()
+    } else {
+      ndjsonStream.once('drain', resolve)
+    }
+  })
+
+  let results = await sdk.document.search(index, collection, {}, options)
+
+  do {
+    process.stdout.write(`  ${results.fetched}/${results.total} documents dumped`)
+    process.stdout.write('\r')
+
+    for (const hit of results.hits) {
+      const document = {
+        _id: hit._id,
+        body: hit._source
+      }
+
+      if (!ndjsonStream.write(document)) {
+        await new Promise(resolve => ndjsonStream.once('drain', resolve))
+      }
+    }
+  } while ((results = await results.next()))
+
+  ndjsonStream.end()
+  writeStream.end()
+
+  return waitWrite
+}
+
+export default dumpCollection

--- a/src/support/restore-collection.ts
+++ b/src/support/restore-collection.ts
@@ -1,6 +1,8 @@
 import chalk from 'chalk'
 import * as fs from 'fs'
-import * as ndjson from 'ndjson'
+
+// tslint:disable-next-line
+const ndjson = require('ndjson')
 
 function handleError(log: any, dumpFile: string, error: any) {
   if (error.status === 206) {

--- a/src/support/restore-collection.ts
+++ b/src/support/restore-collection.ts
@@ -1,0 +1,95 @@
+import chalk from 'chalk'
+import * as fs from 'fs'
+import * as ndjson from 'ndjson'
+
+function handleError(log: any, dumpFile: string, error: any) {
+  if (error.status === 206) {
+    const
+      errorFile = `${dumpFile.split('.').slice(0, -1).join('.')}-errors.jsonl`
+    const writeStream = fs.createWriteStream(errorFile, { flags: 'a' })
+    const serialize = ndjson.serialize().pipe(writeStream)
+
+    serialize.on('data', (line: string) => (writeStream.write(line)))
+
+    for (const partialError of error.errors) {
+      serialize.write(partialError)
+    }
+
+    serialize.end()
+
+    log(chalk.red(`[ℹ] Error importing ${dumpFile}. See errors in ${errorFile}`))
+  } else {
+    log(chalk.red(error.message))
+  }
+  throw error
+}
+
+function restoreCollection(sdk: any, log: any, batchSize: number, dumpFile: string, index?: string, collection?: string) {
+  const mWriteRequest = {
+    controller: 'bulk',
+    action: 'mWrite',
+    index: '',
+    collection: '',
+    body: {
+      documents: [{}]
+    }
+  }
+
+  return new Promise(resolve => {
+    let
+      total = 0
+    let headerSkipped = false
+    let documents: any[] = []
+
+    const readStream = fs.createReadStream(dumpFile)
+      .pipe(ndjson.parse())
+      .on('data', (obj: any) => {
+        if (headerSkipped) {
+          documents.push(obj)
+
+          if (documents.length === batchSize) {
+            mWriteRequest.body.documents = documents
+            documents = []
+
+            readStream.pause()
+
+            sdk.query(mWriteRequest)
+              .catch((error: any) => {
+                handleError(log, dumpFile, error)
+                readStream.resume()
+              })
+              .then(() => {
+                total += mWriteRequest.body.documents.length
+                process.stdout.write(`  ${total} documents handled`)
+                process.stdout.write('\r')
+
+                readStream.resume()
+              })
+          }
+        } else {
+          headerSkipped = true
+          mWriteRequest.index = index || obj.index
+          mWriteRequest.collection = collection || obj.collection
+        }
+      })
+      .on('end', () => {
+        if (documents.length > 0) {
+          mWriteRequest.body.documents = documents
+
+          sdk.query(mWriteRequest)
+            .catch((error: any) => handleError(log, dumpFile, error))
+            .then(() => {
+              total += mWriteRequest.body.documents.length
+              process.stdout.write(`  ${total} documents handled`)
+              process.stdout.write('\r')
+
+              resolve()
+            })
+        } else {
+          resolve()
+        }
+      })
+  })
+}
+
+export default restoreCollection


### PR DESCRIPTION
## What does this PR do?

Add `index:dump`, `index:restore`, `collection:dump` and `collection:restore`

#### `kourou collection:dump INDEX COLLECTION`

Dump an entire collection content (JSONL format)

```
USAGE
  $ kourou collection:dump INDEX COLLECTION

ARGUMENTS
  INDEX       Index name
  COLLECTION  Collection name

OPTIONS
  -h, --host=host          [default: localhost] Kuzzle server host
  -p, --port=port          [default: 7512] Kuzzle server port
  --batch-size=batch-size  [default: 5000] Maximum batch size (see limits.documentsFetchCount config)
  --help                   show CLI help
  --password=password      Kuzzle user password
  --path=path              Dump directory (default: index name)
  --ssl                    Use SSL to connect to Kuzzle
  --username=username      [default: anonymous] Kuzzle user
```

#### `kourou collection:restore PATH`

Restore the content of a previously dumped collection

```
USAGE
  $ kourou collection:restore PATH

ARGUMENTS
  PATH  Dump file path

OPTIONS
  -h, --host=host          [default: localhost] Kuzzle server host
  -p, --port=port          [default: 7512] Kuzzle server port
  --batch-size=batch-size  [default: 5000] Maximum batch size (see limits.documentsFetchCount config)
  --collection=collection  If set, override the collection destination name
  --help                   show CLI help
  --index=index            If set, override the index destination name
  --password=password      Kuzzle user password
  --ssl                    Use SSL to connect to Kuzzle
  --username=username      [default: anonymous] Kuzzle user
```

#### `kourou index:dump INDEX`

Dump an entire index content (JSONL format)

```
USAGE
  $ kourou index:dump INDEX

ARGUMENTS
  INDEX  Index name

OPTIONS
  -h, --host=host          [default: localhost] Kuzzle server host
  -p, --port=port          [default: 7512] Kuzzle server port
  --batch-size=batch-size  [default: 5000] Maximum batch size (see limits.documentsFetchCount config)
  --help                   show CLI help
  --password=password      Kuzzle user password
  --path=path              Dump directory (default: index name)
  --ssl                    Use SSL to connect to Kuzzle
  --username=username      [default: anonymous] Kuzzle user
```

#### `kourou index:restore PATH`

Restore the content of a previously dumped index

```
USAGE
  $ kourou index:restore PATH

ARGUMENTS
  PATH  Dump directory or file

OPTIONS
  -h, --host=host          [default: localhost] Kuzzle server host
  -p, --port=port          [default: 7512] Kuzzle server port
  --batch-size=batch-size  [default: 5000] Maximum batch size (see limits.documentsFetchCount config)
  --help                   show CLI help
  --index=index            If set, override the index destination name
  --password=password      Kuzzle user password
  --ssl                    Use SSL to connect to Kuzzle
  --username=username      [default: anonymous] Kuzzle user
```
