### PR TITLE
Add dumping of collection mappings

### DIFF
--- a/features/Collection.feature
+++ b/features/Collection.feature
@@ -7,16 +7,25 @@ Feature: Collection Commands
       | _id               | body                              |
       | "chuon-chuon-kim" | { "city": "hcmc", "district": 1 } |
       | "the-hive"        | { "city": "hcmc", "district": 2 } |
+    # collection:dump
     When I run the command "collection:dump" with args:
       | "nyc-open-data" |
       | "yellow-taxi"   |
-    And I truncate the collection "nyc-open-data":"yellow-taxi"
+    Then I successfully call the route "collection":"delete" with args:
+      | index      | "nyc-open-data" |
+      | collection | "yellow-taxi"   |
+    # collection:restore
     And I run the command "collection:restore" with args:
-      | "nyc-open-data/collection-yellow-taxi.jsonl" |
+      | "nyc-open-data/yellow-taxi" |
     Then The document "chuon-chuon-kim" content match:
       | city     | "hcmc" |
       | district | 1      |
     And The document "the-hive" content match:
       | city     | "hcmc" |
       | district | 2      |
-
+    Then I successfully call the route "collection":"getMapping" with args:
+      | index      | "nyc-open-data" |
+      | collection | "yellow-taxi"   |
+    And The property "properties" of the result should match:
+      | city | { "type": "keyword" } |
+      | name | { "type": "keyword" } |

--- a/features/Index.feature
+++ b/features/Index.feature
@@ -12,10 +12,12 @@ Feature: Index Commands
       | _id                | body                              |
       | "chuon-chuon-kim2" | { "city": "hcmc", "district": 1 } |
       | "the-hive2"        | { "city": "hcmc", "district": 2 } |
+    # index:dump
     When I run the command "index:dump" with args:
       | "nyc-open-data" |
     And I successfully call the route "index":"delete" with args:
-      | "nyc-open-data" |
+      | index | "nyc-open-data" |
+    # index:restore
     And I run the command "index:restore" with args:
       | "nyc-open-data" |
     Then The document "chuon-chuon-kim2" content match:
@@ -32,8 +34,8 @@ Feature: Index Commands
       | city     | "hcmc" |
       | district | 2      |
     Then I successfully call the route "collection":"getMapping" with args:
-      | "nyc-open-data" |
-      | "yellow-taxi"   |
+      | index      | "nyc-open-data" |
+      | collection | "yellow-taxi"   |
     And The property "properties" of the result should match:
       | city | { "type": "keyword" } |
       | name | { "type": "keyword" } |

--- a/features/Index.feature
+++ b/features/Index.feature
@@ -14,8 +14,8 @@ Feature: Index Commands
       | "the-hive2"        | { "city": "hcmc", "district": 2 } |
     When I run the command "index:dump" with args:
       | "nyc-open-data" |
-    And I truncate the collection "nyc-open-data":"yellow-taxi"
-    And I truncate the collection "nyc-open-data":"green-taxi"
+    And I successfully call the route "index":"delete" with args:
+      | "nyc-open-data" |
     And I run the command "index:restore" with args:
       | "nyc-open-data" |
     Then The document "chuon-chuon-kim2" content match:
@@ -31,4 +31,10 @@ Feature: Index Commands
     And The document "the-hive" content match:
       | city     | "hcmc" |
       | district | 2      |
+    Then I successfully call the route "collection":"getMapping" with args:
+      | "nyc-open-data" |
+      | "yellow-taxi"   |
+    And The property "properties" of the result should match:
+      | city | { "type": "keyword" } |
+      | name | { "type": "keyword" } |
 

--- a/features/fixtures/mappings.js
+++ b/features/fixtures/mappings.js
@@ -3,6 +3,8 @@ module.exports = {
   'nyc-open-data': {
     'yellow-taxi': {
       properties: {
+        name: { type: "keyword" },
+        city: { type: "keyword" },
       }
     }
   }

--- a/features/step_definitions/common/index-steps.js
+++ b/features/step_definitions/common/index-steps.js
@@ -1,7 +1,7 @@
 const
   { Given } = require('cucumber');
 
-Given('an index {string}', async function (index, ) {
+Given('an index {string}', async function (index) {
   this.props.result = await this.sdk.index.create(index);
 
   this.props.index = index;

--- a/src/commands/collection/dump.ts
+++ b/src/commands/collection/dump.ts
@@ -1,7 +1,7 @@
 import { flags } from '@oclif/command'
 import { Kommand } from '../../common'
 import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
-import dumpCollection from '../../support/dump-collection'
+import { dumpCollectionData, dumpCollectionMappings } from '../../support/dump-collection'
 import * as fs from 'fs'
 import chalk from 'chalk'
 
@@ -11,11 +11,11 @@ export default class CollectionDump extends Kommand {
   static flags = {
     help: flags.help({}),
     path: flags.string({
-      description: 'Dump directory (default: index name)',
+      description: 'Dump root directory (default: index name)',
     }),
     'batch-size': flags.string({
       description: 'Maximum batch size (see limits.documentsFetchCount config)',
-      default: '5000'
+      default: '2000'
     }),
     ...kuzzleFlags,
   }
@@ -35,11 +35,17 @@ export default class CollectionDump extends Kommand {
     const sdk = new KuzzleSDK(userFlags)
     await sdk.init()
 
-    this.log(`Dumping collection "${args.index}:${args.collection}" in ${path}/ ...`)
+    this.log(chalk.green(`Dumping collection "${args.index}:${args.collection}" in ${path}/ ...`))
 
     fs.mkdirSync(path, { recursive: true })
 
-    await dumpCollection(
+    await dumpCollectionMappings(
+      sdk,
+      args.index,
+      args.collection,
+      path)
+
+    await dumpCollectionData(
       sdk,
       args.index,
       args.collection,

--- a/src/commands/collection/restore.ts
+++ b/src/commands/collection/restore.ts
@@ -2,7 +2,7 @@ import { flags } from '@oclif/command'
 import { Kommand } from '../../common'
 import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
 import chalk from 'chalk'
-import restoreCollection from '../../support/restore-collection'
+import { restoreCollectionData, restoreCollectionMappings } from '../../support/restore-collection'
 
 export default class CollectionRestore extends Kommand {
   static description = 'Restore the content of a previously dumped collection'
@@ -10,8 +10,8 @@ export default class CollectionRestore extends Kommand {
   static flags = {
     help: flags.help({}),
     'batch-size': flags.string({
-      description: 'Maximum batch size (see limits.documentsFetchCount config)',
-      default: '5000'
+      description: 'Maximum batch size (see limits.documentsWriteCount config)',
+      default: '200'
     }),
     index: flags.string({
       description: 'If set, override the index destination name',
@@ -19,11 +19,15 @@ export default class CollectionRestore extends Kommand {
     collection: flags.string({
       description: 'If set, override the collection destination name',
     }),
+    mappings: flags.boolean({
+      description: 'Restore the collection mappings',
+      default: true
+    }),
     ...kuzzleFlags,
   }
 
   static args = [
-    { name: 'path', description: 'Dump file path', required: true },
+    { name: 'path', description: 'Dump directory path', required: true },
   ]
 
   async run() {
@@ -41,7 +45,15 @@ export default class CollectionRestore extends Kommand {
     this.log(chalk.green(`[✔] Start importing dump from ${args.path}`))
 
     try {
-      await restoreCollection(
+      if (userFlags.mappings) {
+        await restoreCollectionMappings(
+          sdk,
+          args.path,
+          index,
+          collection)
+      }
+
+      await restoreCollectionData(
         sdk,
         this.log.bind(this),
         Number(userFlags['batch-size']),
@@ -50,7 +62,8 @@ export default class CollectionRestore extends Kommand {
         collection)
 
       this.log(chalk.green(`[✔] Dump file ${args.path} imported`))
-    } catch (error) {
+    }
+    catch (error) {
       this.log(chalk.red(`[ℹ] Error while importing: ${error.message}`))
     }
   }

--- a/src/commands/index/dump.ts
+++ b/src/commands/index/dump.ts
@@ -56,7 +56,7 @@ export default class IndexDump extends Kommand {
           Number(userFlags['batch-size']),
           path)
 
-        cli.action.stop();
+        cli.action.stop()
       }
     }
 

--- a/src/commands/index/dump.ts
+++ b/src/commands/index/dump.ts
@@ -1,8 +1,9 @@
 import { flags } from '@oclif/command'
 import { Kommand } from '../../common'
 import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
-import dumpCollection from '../../support/dump-collection'
+import { dumpCollectionData, dumpCollectionMappings } from '../../support/dump-collection'
 import * as fs from 'fs'
+import cli from 'cli-ux'
 import chalk from 'chalk'
 
 export default class IndexDump extends Kommand {
@@ -15,7 +16,7 @@ export default class IndexDump extends Kommand {
     }),
     'batch-size': flags.string({
       description: 'Maximum batch size (see limits.documentsFetchCount config)',
-      default: '5000'
+      default: '2000'
     }),
     ...kuzzleFlags,
   }
@@ -34,7 +35,7 @@ export default class IndexDump extends Kommand {
     const sdk = new KuzzleSDK(userFlags)
     await sdk.init()
 
-    this.log(`Dumping index "${args.index}" in ${path}/ ...`)
+    this.log(chalk.green(`Dumping index "${args.index}" in ${path}/ ...`))
 
     fs.mkdirSync(path, { recursive: true })
 
@@ -42,15 +43,23 @@ export default class IndexDump extends Kommand {
 
     for (const collection of collections) {
       if (collection.type !== 'realtime') {
-        await dumpCollection(
+        await dumpCollectionMappings(
+          sdk,
+          args.index,
+          collection.name,
+          path)
+
+        await dumpCollectionData(
           sdk,
           args.index,
           collection.name,
           Number(userFlags['batch-size']),
           path)
 
-        this.log(chalk.green(`[✔] Collection ${args.index}:${collection.name} dumped`))
+        cli.action.stop();
       }
     }
+
+    this.log(chalk.green(`[✔] Index ${args.index} dumped`))
   }
 }

--- a/src/commands/index/restore.ts
+++ b/src/commands/index/restore.ts
@@ -3,7 +3,7 @@ import { Kommand } from '../../common'
 import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
 import * as fs from 'fs'
 import chalk from 'chalk'
-import restoreCollection from '../../support/restore-collection'
+import { restoreCollectionData, restoreCollectionMappings } from '../../support/restore-collection'
 
 export default class IndexRestore extends Kommand {
   static description = 'Restore the content of a previously dumped index'
@@ -11,11 +11,15 @@ export default class IndexRestore extends Kommand {
   static flags = {
     help: flags.help({}),
     'batch-size': flags.string({
-      description: 'Maximum batch size (see limits.documentsFetchCount config)',
-      default: '5000'
+      description: 'Maximum batch size (see limits.documentsWriteCount config)',
+      default: '200'
     }),
     index: flags.string({
       description: 'If set, override the index destination name',
+    }),
+    mappings: flags.boolean({
+      description: 'Restore collections mappings',
+      default: true
     }),
     ...kuzzleFlags,
   }
@@ -37,25 +41,36 @@ export default class IndexRestore extends Kommand {
 
     if (index) {
       this.log(chalk.green(`[✔] Start importing dump from ${args.path} in index ${index}`))
-    } else {
+    }
+    else {
       this.log(chalk.green(`[✔] Start importing dump from ${args.path} in same index`))
     }
 
-    const dumpFiles = fs.readdirSync(args.path).map(f => `${args.path}/${f}`)
+    const dumpDirs = fs.readdirSync(args.path).map(f => `${args.path}/${f}`)
 
     try {
-      for (const dumpFile of dumpFiles) {
-        await restoreCollection(
+      if (! await sdk.index.exists(index)) {
+        await sdk.index.create(index);
+      }
+
+      for (const dumpDir of dumpDirs) {
+        await restoreCollectionMappings(
+          sdk,
+          dumpDir,
+          index)
+
+        await restoreCollectionData(
           sdk,
           this.log.bind(this),
           Number(userFlags['batch-size']),
-          dumpFile,
+          dumpDir,
           index)
 
         if (index) {
-          this.log(chalk.green(`[✔] Dump file ${dumpFile} imported in index ${index}`))
-        } else {
-          this.log(chalk.green(`[✔] Dump file ${dumpFile} imported`))
+          this.log(chalk.green(`[✔] Dump directory ${dumpDir} imported in index ${index}`))
+        }
+        else {
+          this.log(chalk.green(`[✔] Dump directory ${dumpDir} imported`))
         }
       }
     } catch (error) {

--- a/src/commands/index/restore.ts
+++ b/src/commands/index/restore.ts
@@ -49,10 +49,6 @@ export default class IndexRestore extends Kommand {
     const dumpDirs = fs.readdirSync(args.path).map(f => `${args.path}/${f}`)
 
     try {
-      if (! await sdk.index.exists(index)) {
-        await sdk.index.create(index);
-      }
-
       for (const dumpDir of dumpDirs) {
         await restoreCollectionMappings(
           sdk,

--- a/src/support/dump-collection.ts
+++ b/src/support/dump-collection.ts
@@ -35,11 +35,11 @@ export async function dumpCollectionData(sdk: any, index: string, collection: st
 
   const progressBar = cli.progress({
     format: `Dumping ${collection} |{bar}| {percentage}% || {value}/{total} documents`
-  });
-  progressBar.start(results.total, 0);
+  })
+  progressBar.start(results.total, 0)
 
   do {
-    progressBar.update(results.fetched);
+    progressBar.update(results.fetched)
 
     for (const hit of results.hits) {
       const document = {
@@ -66,13 +66,13 @@ export async function dumpCollectionMappings(sdk: any, index: string, collection
 
   fs.mkdirSync(collectionDir, { recursive: true })
 
-  const mappings = await sdk.collection.getMapping(index, collection);
+  const mappings = await sdk.collection.getMapping(index, collection)
 
   const content = {
     [index]: {
       [collection]: mappings
     }
-  };
+  }
 
-  fs.writeFileSync(filename, JSON.stringify(content, null, 2));
+  fs.writeFileSync(filename, JSON.stringify(content, null, 2))
 }

--- a/src/support/dump-collection.ts
+++ b/src/support/dump-collection.ts
@@ -1,10 +1,12 @@
 import * as fs from 'fs'
+import cli from 'cli-ux'
 
 // tslint:disable-next-line
 const ndjson = require('ndjson')
 
-async function dumpCollection(sdk: any, index: string, collection: string, batchSize: number, path: string) {
-  const filename = `${path}/collection-${collection}.jsonl`
+export async function dumpCollectionData(sdk: any, index: string, collection: string, batchSize: number, path: string) {
+  const collectionDir = `${path}/${collection}`
+  const filename = `${collectionDir}/documents.jsonl`
   const writeStream = fs.createWriteStream(filename)
   const waitWrite = new Promise(resolve => writeStream.on('finish', resolve))
   const ndjsonStream = ndjson.serialize()
@@ -19,6 +21,8 @@ async function dumpCollection(sdk: any, index: string, collection: string, batch
 
   ndjsonStream.on('data', (line: string) => writeStream.write(line))
 
+  fs.mkdirSync(collectionDir, { recursive: true })
+
   await new Promise(resolve => {
     if (ndjsonStream.write({ index: index, collection })) {
       resolve()
@@ -29,9 +33,13 @@ async function dumpCollection(sdk: any, index: string, collection: string, batch
 
   let results = await sdk.document.search(index, collection, {}, options)
 
+  const progressBar = cli.progress({
+    format: `Dumping ${collection} |{bar}| {percentage}% || {value}/{total} documents`
+  });
+  progressBar.start(results.total, 0);
+
   do {
-    process.stdout.write(`  ${results.fetched}/${results.total} documents dumped`)
-    process.stdout.write('\r')
+    progressBar.update(results.fetched);
 
     for (const hit of results.hits) {
       const document = {
@@ -45,10 +53,26 @@ async function dumpCollection(sdk: any, index: string, collection: string, batch
     }
   } while ((results = await results.next()))
 
+  progressBar.stop()
   ndjsonStream.end()
   writeStream.end()
 
   return waitWrite
 }
 
-export default dumpCollection
+export async function dumpCollectionMappings(sdk: any, index: string, collection: string, path: string) {
+  const collectionDir = `${path}/${collection}`
+  const filename = `${collectionDir}/mappings.json`
+
+  fs.mkdirSync(collectionDir, { recursive: true })
+
+  const mappings = await sdk.collection.getMapping(index, collection);
+
+  const content = {
+    [index]: {
+      [collection]: mappings
+    }
+  };
+
+  fs.writeFileSync(filename, JSON.stringify(content, null, 2));
+}

--- a/src/support/kuzzle.ts
+++ b/src/support/kuzzle.ts
@@ -74,4 +74,8 @@ export class KuzzleSDK {
   get collection() {
     return this.sdk.collection
   }
+
+  get index() {
+    return this.sdk.index
+  }
 }

--- a/src/support/restore-collection.ts
+++ b/src/support/restore-collection.ts
@@ -23,12 +23,12 @@ function handleError(log: any, dumpFile: string, error: any) {
   }
   else {
     log(chalk.red(error.message))
-    throw error;
+    throw error
   }
 }
 
 export async function restoreCollectionData(sdk: any, log: any, batchSize: number, dumpDir: string, index?: string, collection?: string) {
-  const dumpFile = `${dumpDir}/documents.jsonl`;
+  const dumpFile = `${dumpDir}/documents.jsonl`
   const mWriteRequest = {
     controller: 'bulk',
     action: 'mWrite',
@@ -131,18 +131,18 @@ export async function restoreCollectionData(sdk: any, log: any, batchSize: numbe
  * @returns {Promise}
  */
 export async function restoreCollectionMappings(sdk: any, dumpDir: string, index?: string, collection?: string) {
-  const dumpFile = `${dumpDir}/mappings.json`;
-  const content: any = JSON.parse(fs.readFileSync(dumpFile, 'utf8'));
+  const dumpFile = `${dumpDir}/mappings.json`
+  const content: any = JSON.parse(fs.readFileSync(dumpFile, 'utf8'))
 
-  const srcIndex: any = Object.keys(content)[0];
-  const srcCollection: any = Object.keys(content[srcIndex])[0];
+  const srcIndex: any = Object.keys(content)[0]
+  const srcCollection: any = Object.keys(content[srcIndex])[0]
 
-  const dstIndex: any = index || srcIndex;
-  const dstCollection: any = collection || srcCollection;
+  const dstIndex: any = index || srcIndex
+  const dstCollection: any = collection || srcCollection
 
-  if (! await sdk.index.exists(dstIndex)) {
+  if (!await sdk.index.exists(dstIndex)) {
     await sdk.index.create(dstIndex)
   }
 
-  return sdk.collection.create(dstIndex, dstCollection, content[srcIndex][srcCollection]);
+  return sdk.collection.create(dstIndex, dstCollection, content[srcIndex][srcCollection])
 }


### PR DESCRIPTION
## What does this PR do?

Also dump the collection mappings alongside the documents.  
In this way, users can import a collection with the same mappings or they can modify the generated file to change the imported mappings
