### PR TITLE
Help messages per topics

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,18 @@
     "bin": "kourou",
     "plugins": [
       "@oclif/plugin-help"
-    ]
+    ],
+    "topics": {
+      "api-key": { "description": "manage API keys" },
+      "collection": { "description": "dump or restore an entire data collection" },
+      "document": { "description": "push or retrieve documents from the data storage" },
+      "es": { "description": "low-level access to Elasticsearch" },
+      "index": { "description": "dump or restore an entire data index"},
+      "instance": { "description": "manage Kuzzle instances" },
+      "profile": { "description": "manage user profiles" },
+      "role": { "description": "manage user roles" },
+      "vault": { "description": "manage then encrypted vault" }
+    }
   },
   "repository": "kuzzleio/kourou",
   "scripts": {


### PR DESCRIPTION
# Description

By default, oclif prints the description of the 1st topic found per command. 
Meaning that, for instance, when running `kourou --help`, the help printed for the "api-key" topic is: `Creates a new API Key for a user`

Which is a bit confusing.

This PR adds a description text per topic, allowing oclif to print the correct help messages.

Before:

```
$ kourou --help
The CLI that helps you manage your Kuzzle instances

VERSION
  kourou/0.7.0 linux-x64 node-v12.16.1

USAGE
  $ kourou [COMMAND]

COMMANDS
  api-key     Creates a new API Key for a user
  collection  Dump an entire collection content (JSONL format)
  document    Creates a document
  es          Gets a document from ES
  help        display help for kourou
  index       Dump an entire index content (JSONL format)
  instance    Displays the logs of a running Kuzzle
  profile     Dumps Kuzzle profiles
  query       Executes an API query
  role        Dumps Kuzzle roles
  vault       Adds an encrypted key to a secrets file
```


After:

```
$ kourou --help
The CLI that helps you manage your Kuzzle instances

VERSION
  kourou/0.7.0 linux-x64 node-v12.16.1

USAGE
  $ kourou [COMMAND]

COMMANDS
  api-key     manage API keys
  collection  dump or restore an entire data collection
  document    push or retrieve documents from the data storage
  es          low-level access to Elasticsearch
  help        display help for kourou
  index       dump or restore an entire data index
  instance    manage Kuzzle instances
  profile     manage user profiles
  query       Executes an API query
  role        manage user roles
  vault       manage then encrypted vault
```