### PR TITLE
Add a shorthand for the --arg argument of the query command

### DIFF
--- a/features/Query.feature
+++ b/features/Query.feature
@@ -7,7 +7,7 @@ Feature: Query
       | arg  | document:createOrReplace |                        |
       | flag | --arg                    | index=nyc-open-data    |
       | flag | --arg                    | collection=yellow-taxi |
-      | flag | --arg                    | _id=chuon-chuon-kim    |
+      | flag | -a                       | _id=chuon-chuon-kim    |
       | flag | --body                   | { "other-name": "my" } |
     Then The document "chuon-chuon-kim" content match:
       | other-name | "my" |

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -9,7 +9,8 @@ class Query extends Kommand {
   public static flags = {
     help: flags.help(),
     arg: flags.string({
-      description: 'Additional argument. Repeatable. (eg: "--arg refresh=wait_for")',
+      char: 'a',
+      description: 'Additional argument. Repeatable. (e.g. "-a refresh=wait_for")',
       multiple: true
     }),
     body: flags.string({


### PR DESCRIPTION
# Description

`kourou query` allows the `--arg` argument to pass query properties.

This argument lacked a shorthand version, making repeating many "--arg" arguments a hassle.

Before:

```
kourou query document:update --arg index=foo --arg collection=bar --arg _id=qux --body '{"foo": "bar"}' --arg refresh=null
```

After:

```
kourou query document:update -a index=foo -a collection=bar -a _id=qux --body '{"foo": "bar"}' -a refresh=null
```