### PR TITLE
Query: prints the full error object for better understanding

### DIFF
--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -62,7 +62,7 @@ class Query extends Kommand {
       this.log(JSON.stringify(response, null, 2))
     }
     catch (error) {
-      this.logError(`${error.stack || error.message}\n${JSON.stringify(error, 0, 2)}`)
+      this.logError(`${error.stack || error.message}\n\tstatus: ${error.status}\n\tid: ${error.id}`)
     }
   }
 }

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -62,7 +62,7 @@ class Query extends Kommand {
       this.log(JSON.stringify(response, null, 2))
     }
     catch (error) {
-      this.logError(`${error.stack || error.message}\n${JSON.stringify(error, 0, 2)}`);
+      this.logError(`${error.stack || error.message}\n${JSON.stringify(error, 0, 2)}`)
     }
   }
 }

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -62,7 +62,7 @@ class Query extends Kommand {
       this.log(JSON.stringify(response, null, 2))
     }
     catch (error) {
-      this.logError(error.message)
+      this.logError(`${error.stack || error.message}\n${JSON.stringify(error, 0, 2)}`);
     }
   }
 }


### PR DESCRIPTION
# Description

When `kourou query` returns an error, we only have the error message. This lacks other information such as the status code, error id and, if available, the Kuzzle stack trace, useful in development mode.

This PR adds all these informations.

Before (dev mode):

```
 [ℹ] Connecting to http://localhost:7512 ...
 ›   Error: Error: NotFoundError: Document "qux" not found.
```

After (kuzzle in production mode):

```
 [ℹ] Connecting to http://localhost:7512 ...
 ›   Error: Error: Document "qux" not found.
 ›   	status: 404
 ›   	id: services.storage.not_found
```

After (kuzzle in development mode):

```
 [ℹ] Connecting to http://localhost:7512 ...
 ›   Error: Error: NotFoundError: Document "qux" not found.
 ›       at new NotFoundError (/var/app/node_modules/kuzzle-common-objects/lib/errors/notFoundError.js:5:5)
 ›       at get (/var/app/lib/util/errors.js:71:10)
 ›       at Object.get (/var/app/lib/util/errors.js:124:38)
 ›       at ESWrapper._handleNotFoundError (/var/app/lib/util/esWrapper.js:211:28)
 ›       at ESWrapper.formatESError (/var/app/lib/util/esWrapper.js:185:23)
 ›       at ESWrapper.reject (/var/app/lib/util/esWrapper.js:197:33)
 ›       at /var/app/lib/services/elasticsearch.js:318:39
 ›       at processTicksAndRejections (internal/process/task_queues.js:93:5)
 ›       at async Validation.validate (/var/app/lib/core/validation/index.js:106:24)
 ›       at async Funnel.processRequest (/var/app/lib/api/funnel.js:433:28)
 ›   	status: 404
 ›   	id: services.storage.not_found
```