### PR TITLE
Allow read from stdin for query and document:create

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,7 +39,7 @@ jobs:
       language: node_js
       node_js: 12
       env:
-        - NODE_env=test
+        - NODE_ENV=test
       cache:
         directories:
           - ~/.npm

--- a/.travis.yml
+++ b/.travis.yml
@@ -38,6 +38,8 @@ jobs:
       name: "Kourou Functional Cucumber Tests"
       language: node_js
       node_js: 12
+      env:
+        - NODE_env=test
       cache:
         directories:
           - ~/.npm

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ ARGUMENTS
 OPTIONS
   -h, --host=host      [default: localhost] Kuzzle server host
   -p, --port=port      [default: 7512] Kuzzle server port
-  --body=body          [default: {}] Document body. Will be read from STDIN if available (JS or JSON format)
+  --body=body          [default: {}] Document body in JS or JSON format. Will be read from STDIN if available
   --help               show CLI help
   --id=id              Optional document ID
   --password=password  Kuzzle user password
@@ -471,7 +471,7 @@ OPTIONS
   -a, --arg=arg        Additional argument. Repeatable. (e.g. "-a refresh=wait_for")
   -h, --host=host      [default: localhost] Kuzzle server host
   -p, --port=port      [default: 7512] Kuzzle server port
-  --body=body          Request body in JSON format. Will be read from STDIN if available (JS or JSON format)
+  --body=body          [default: {}] Request body in JS or JSON format. Will be read from STDIN if available.
   --help               show CLI help
   --password=password  Kuzzle user password
   --ssl                Use SSL to connect to Kuzzle

--- a/README.md
+++ b/README.md
@@ -218,13 +218,17 @@ ARGUMENTS
 OPTIONS
   -h, --host=host      [default: localhost] Kuzzle server host
   -p, --port=port      [default: 7512] Kuzzle server port
-  --body=body          (required) Document body in JSON format
+  --body=body          [default: {}] Document body. Will be read from STDIN if available (JS or JSON format)
   --help               show CLI help
   --id=id              Optional document ID
   --password=password  Kuzzle user password
   --replace            Replaces the document if it already exists
   --ssl                Use SSL to connect to Kuzzle
   --username=username  [default: anonymous] Kuzzle username (local strategy)
+
+EXAMPLES
+  kourou document:create iot sensors --body '{network: "sigfox"}'
+  kourou document:create iot sensors < document.json
 ```
 
 _See code: [src/commands/document/create.ts](https://github.com/kuzzleio/kourou/blob/v0.7.0/src/commands/document/create.ts)_
@@ -464,14 +468,20 @@ ARGUMENTS
   CONTROLLER:ACTION  Controller and action (eg: "server:now")
 
 OPTIONS
+  -a, --arg=arg        Additional argument. Repeatable. (e.g. "-a refresh=wait_for")
   -h, --host=host      [default: localhost] Kuzzle server host
   -p, --port=port      [default: 7512] Kuzzle server port
-  --arg=arg            Additional argument. Repeatable. (eg: "--arg refresh=wait_for")
-  --body=body          Request body in JSON format.
+  --body=body          Request body in JSON format. Will be read from STDIN if available (JS or JSON format)
   --help               show CLI help
   --password=password  Kuzzle user password
   --ssl                Use SSL to connect to Kuzzle
   --username=username  [default: anonymous] Kuzzle username (local strategy)
+
+EXAMPLES
+  kourou query document:get --arg index=iot --arg collection=sensors --arg _id=sigfox-42
+  kourou query collection:create --arg index=iot --arg collection=sensors --body '{dynamic: "strict"}'
+  kourou query admin:loadMappings < mappings.json
+  echo '{name: "Aschen"}' | kourou query document:create --arg index=iot --arg collection=sensors
 ```
 
 _See code: [src/commands/query.ts](https://github.com/kuzzleio/kourou/blob/v0.7.0/src/commands/query.ts)_

--- a/features/docker/docker-compose.yml
+++ b/features/docker/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - kuzzle_services__storageEngine__client__node=http://elasticsearch:9200
       - kuzzle_services__internalCache__node__host=redis
       - kuzzle_services__memoryStorage__node__host=redis
-      - NODE_ENV=development
+      - NODE_ENV=test
       - DEBUG=kuzzle:*,-kuzzle:entry-point:protocols:websocket
 
   redis:

--- a/features/step_definitions/common/documents-steps.js
+++ b/features/step_definitions/common/documents-steps.js
@@ -108,7 +108,7 @@ Then(/The document "(.*?)" should( not)? exist/, async function (id, not) {
 Then(/I "(.*?)" the following document ids( with verb "(.*?)")?:/, async function (action, verb, dataTable) {
   action = `m${action[0].toUpperCase() + action.slice(1)}`;
   const options = verb ? { verb, refresh: 'wait_for' } : { refresh: 'wait_for' };
-  console.log(options);
+
   const ids = _.flatten(dataTable.rawTable).map(JSON.parse);
 
   this.props.result = await this.sdk.document[action](

--- a/src/commands/document/create.ts
+++ b/src/commands/document/create.ts
@@ -12,7 +12,7 @@ export default class DocumentCreate extends Kommand {
 
   static flags = {
     body: flags.string({
-      description: 'Document body. Will be read from STDIN if available (JS or JSON format)',
+      description: 'Document body in JS or JSON format. Will be read from STDIN if available',
       default: '{}'
     }),
     id: flags.string({

--- a/src/commands/document/create.ts
+++ b/src/commands/document/create.ts
@@ -5,10 +5,15 @@ import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
 export default class DocumentCreate extends Kommand {
   static description = 'Creates a document'
 
+  static examples = [
+    'kourou document:create iot sensors --body \'{network: "sigfox"}\'',
+    'kourou document:create iot sensors < document.json',
+  ]
+
   static flags = {
     body: flags.string({
-      description: 'Document body in JSON format',
-      required: true
+      description: 'Document body. Will be read from STDIN if available (JS or JSON format)',
+      default: '{}'
     }),
     id: flags.string({
       description: 'Optional document ID'
@@ -42,10 +47,10 @@ export default class DocumentCreate extends Kommand {
     const sdk = new KuzzleSDK(userFlags)
     await sdk.init(this.log)
 
+    const body = this.fromStdin(userFlags.body)
+
     try {
       let document: any
-
-      const body = JSON.parse(userFlags.body)
 
       if (userFlags.replace) {
         document = await sdk.document.replace(

--- a/src/commands/document/create.ts
+++ b/src/commands/document/create.ts
@@ -47,7 +47,7 @@ export default class DocumentCreate extends Kommand {
     const sdk = new KuzzleSDK(userFlags)
     await sdk.init(this.log)
 
-    const body = this.fromStdin(userFlags.body)
+    const body = await this.fromStdin(userFlags.body)
 
     try {
       let document: any

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -58,7 +58,7 @@ class Query extends Kommand {
     }
 
     // try to read stdin, otherwise use the "body" flag
-    const body = await this.fromStdin(JSON.parse(userFlags.body))
+    const body = await this.fromStdin(userFlags.body)
 
     const request = {
       controller,

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -21,7 +21,8 @@ class Query extends Kommand {
       multiple: true
     }),
     body: flags.string({
-      description: 'Request body in JSON format. Will be read from STDIN if available (JS or JSON format)'
+      description: 'Request body in JS or JSON format. Will be read from STDIN if available.',
+      default: '{}'
     }),
     ...kuzzleFlags,
   };
@@ -57,7 +58,7 @@ class Query extends Kommand {
     }
 
     // try to read stdin, otherwise use the "body" flag
-    const body = await this.fromStdin(JSON.parse(userFlags.body || '{}'))
+    const body = await this.fromStdin(JSON.parse(userFlags.body))
 
     const request = {
       controller,

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -6,6 +6,13 @@ import chalk from 'chalk'
 class Query extends Kommand {
   public static description = 'Executes an API query';
 
+  public static examples = [
+    'kourou query document:get --arg index=iot --arg collection=sensors --arg _id=sigfox-42',
+    'kourou query collection:create --arg index=iot --arg collection=sensors --body \'{dynamic: "strict"}\'',
+    'kourou query admin:loadMappings < mappings.json',
+    'echo \'{name: "Aschen"}\' | kourou query document:create --arg index=iot --arg collection=sensors'
+  ]
+
   public static flags = {
     help: flags.help(),
     arg: flags.string({
@@ -14,7 +21,7 @@ class Query extends Kommand {
       multiple: true
     }),
     body: flags.string({
-      description: 'Request body in JSON format.'
+      description: 'Request body in JSON format. Will be read from STDIN if available (JS or JSON format)'
     }),
     ...kuzzleFlags,
   };
@@ -49,11 +56,14 @@ class Query extends Kommand {
       requestArgs[key] = value.join()
     }
 
+    // try to read stdin, otherwise use the "body" flag
+    const body = await this.fromStdin(JSON.parse(userFlags.body || '{}'))
+
     const request = {
       controller,
       action,
       ...requestArgs,
-      body: JSON.parse(userFlags.body || '{}'),
+      body,
     }
 
     try {

--- a/src/common.ts
+++ b/src/common.ts
@@ -22,10 +22,17 @@ export abstract class Kommand extends Command {
   /**
    * Reads a value from STDIN or return the default value.
    * This method can parse both JSON string and JS string
+   *
+   * @param {String} defaultValue - Default value if nothing is written on STDIN
+   *
+   * @returns {Promise<String>} Parsed input
    */
   fromStdin(defaultValue: string) {
     return new Promise(resolve => {
-      let input: any = defaultValue
+      if (process.stdin.isTTY) {
+        resolve(this._parseInput(defaultValue))
+      }
+      let input: any;
 
       process.stdin.on('data', data => {
         input = data.toString()

--- a/src/common.ts
+++ b/src/common.ts
@@ -1,6 +1,7 @@
 import { Command } from '@oclif/command'
 import chalk from 'chalk'
 import emoji from 'node-emoji'
+import fs from 'fs'
 
 export abstract class Kommand extends Command {
   public printCommand() {
@@ -29,18 +30,15 @@ export abstract class Kommand extends Command {
    */
   fromStdin(defaultValue: string) {
     return new Promise(resolve => {
-      if (process.stdin.isTTY) {
+      // cucumber mess with stdin so I have to do this trick
+      if (process.env.NODE_ENV === 'test' || process.stdin.isTTY) {
         resolve(this._parseInput(defaultValue))
         return
       }
 
-      let input: any
+      const input = fs.readFileSync(0, 'utf8')
 
-      process.stdin.on('data', data => {
-        input = data.toString()
-      })
-
-      process.stdin.on('end', () => resolve(this._parseInput(input)))
+      resolve(this._parseInput(input))
     })
   }
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -16,7 +16,28 @@ export abstract class Kommand extends Command {
   }
 
   public logError(message?: string | undefined, ...args: any[]): void {
-    process.exitCode = 1
     return this.error(chalk.red(message), ...args)
   }
+
+  /**
+   * Reads a value from STDIN or return the default value.
+   * This method can parse both JSON string and JS string
+   * @param defaultValue
+   */
+  fromStdin(defaultValue: string) {
+    return new Promise(resolve => {
+      let input: any = defaultValue
+
+      process.stdin.on('data', data => {
+        input = data.toString()
+      });
+
+      process.stdin.on('end', () => resolve(this._parseInput(input)))
+    });
+  }
+
+  public _parseInput(input: string) {
+    return eval(`var o = ${input}; o`)
+  }
+
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -22,7 +22,6 @@ export abstract class Kommand extends Command {
   /**
    * Reads a value from STDIN or return the default value.
    * This method can parse both JSON string and JS string
-   * @param defaultValue
    */
   fromStdin(defaultValue: string) {
     return new Promise(resolve => {
@@ -30,14 +29,14 @@ export abstract class Kommand extends Command {
 
       process.stdin.on('data', data => {
         input = data.toString()
-      });
+      })
 
       process.stdin.on('end', () => resolve(this._parseInput(input)))
-    });
+    })
   }
 
   public _parseInput(input: string) {
+    // eslint-disable-next-line no-eval
     return eval(`var o = ${input}; o`)
   }
-
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -31,8 +31,10 @@ export abstract class Kommand extends Command {
     return new Promise(resolve => {
       if (process.stdin.isTTY) {
         resolve(this._parseInput(defaultValue))
+        return
       }
-      let input: any;
+
+      let input: any
 
       process.stdin.on('data', data => {
         input = data.toString()


### PR DESCRIPTION
## What does this PR do?

Allows to read input body from STDIN for the following commands: `query` and `document:create`

The body can either be a JS or JSON string.
