### PR TITLE
Add vault:test

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ By environment variables:
 * [`kourou vault:add SECRETS-FILE KEY VALUE`](#kourou-vaultadd-secrets-file-key-value)
 * [`kourou vault:encrypt FILE`](#kourou-vaultencrypt-file)
 * [`kourou vault:show SECRETS-FILE KEY`](#kourou-vaultshow-secrets-file-key)
+* [`kourou vault:test SECRETS-FILE`](#kourou-vaulttest-secrets-file)
 
 ## `kourou api-key:create USER`
 
@@ -585,6 +586,23 @@ OPTIONS
 ```
 
 _See code: [src/commands/vault/show.ts](https://github.com/kuzzleio/kourou/blob/v0.8.0/src/commands/vault/show.ts)_
+
+## `kourou vault:test SECRETS-FILE`
+
+Tests if an encrypted secrets file can be decrypted.
+
+```
+USAGE
+  $ kourou vault:test SECRETS-FILE
+
+ARGUMENTS
+  SECRETS-FILE  Encrypted secrets file
+
+OPTIONS
+  --vault-key=vault-key  Kuzzle Vault Key (or KUZZLE_VAULT_KEY)
+```
+
+_See code: [src/commands/vault/test.ts](https://github.com/kuzzleio/kourou/blob/v0.8.0/src/commands/vault/test.ts)_
 <!-- commandsstop -->
 
 # Where does this weird name comes from?

--- a/features/Vault.feature
+++ b/features/Vault.feature
@@ -42,3 +42,14 @@ Feature: Vault
       | flag | --vault-key           | "secret-password" |
     And I should match stdout with "foobar"
 
+  @vault
+  Scenario: Encrypt a secrets file
+    Given a JSON file "test-secrets.json" containing:
+      | aws.s3   | "foobar" |
+      | my.huong | "hcmc"   |
+    And I run the command "vault:encrypt" with:
+      | arg  | test-secrets.json |                   |
+      | flag | --vault-key       | "secret-password" |
+    When I run the command "vault:test" with:
+      | arg  | test-secrets.enc.json |                   |
+      | flag | --vault-key           | "secret-password" |

--- a/src/commands/collection/dump.ts
+++ b/src/commands/collection/dump.ts
@@ -41,7 +41,7 @@ export default class CollectionDump extends Kommand {
 
     const path = userFlags.path || args.index
 
-    const sdk = new KuzzleSDK(userFlags)
+    const sdk = new KuzzleSDK({ refreshLogin: true, ...userFlags })
     await sdk.init(this.log)
 
     this.log(chalk.green(`Dumping collection "${args.index}:${args.collection}" in ${path}/ ...`))

--- a/src/commands/collection/dump.ts
+++ b/src/commands/collection/dump.ts
@@ -41,7 +41,7 @@ export default class CollectionDump extends Kommand {
 
     const path = userFlags.path || args.index
 
-    const sdk = new KuzzleSDK({ refreshLogin: true, ...userFlags })
+    const sdk = new KuzzleSDK({ loginTTL: true, ...userFlags })
     await sdk.init(this.log)
 
     this.log(chalk.green(`Dumping collection "${args.index}:${args.collection}" in ${path}/ ...`))

--- a/src/commands/collection/restore.ts
+++ b/src/commands/collection/restore.ts
@@ -46,7 +46,7 @@ export default class CollectionRestore extends Kommand {
     const index = userFlags.index
     const collection = userFlags.collection
 
-    const sdk = new KuzzleSDK(userFlags)
+    const sdk = new KuzzleSDK({ refreshLogin: true, ...userFlags })
 
     await sdk.init(this.log)
 

--- a/src/commands/collection/restore.ts
+++ b/src/commands/collection/restore.ts
@@ -46,7 +46,7 @@ export default class CollectionRestore extends Kommand {
     const index = userFlags.index
     const collection = userFlags.collection
 
-    const sdk = new KuzzleSDK({ refreshLogin: true, ...userFlags })
+    const sdk = new KuzzleSDK({ loginTTL: true, ...userFlags })
 
     await sdk.init(this.log)
 

--- a/src/commands/index/dump.ts
+++ b/src/commands/index/dump.ts
@@ -41,7 +41,7 @@ export default class IndexDump extends Kommand {
 
     const path = userFlags.path || args.index
 
-    const sdk = new KuzzleSDK(userFlags)
+    const sdk = new KuzzleSDK({ refreshLogin: true, ...userFlags })
     await sdk.init(this.log)
 
     this.log(chalk.green(`Dumping index "${args.index}" in ${path}/ ...`))

--- a/src/commands/index/dump.ts
+++ b/src/commands/index/dump.ts
@@ -41,7 +41,7 @@ export default class IndexDump extends Kommand {
 
     const path = userFlags.path || args.index
 
-    const sdk = new KuzzleSDK({ refreshLogin: true, ...userFlags })
+    const sdk = new KuzzleSDK({ loginTTL: true, ...userFlags })
     await sdk.init(this.log)
 
     this.log(chalk.green(`Dumping index "${args.index}" in ${path}/ ...`))

--- a/src/commands/index/restore.ts
+++ b/src/commands/index/restore.ts
@@ -43,7 +43,7 @@ export default class IndexRestore extends Kommand {
 
     const index = userFlags.index
 
-    const sdk = new KuzzleSDK(userFlags)
+    const sdk = new KuzzleSDK({ refreshLogin: true, ...userFlags })
 
     await sdk.init(this.log)
 

--- a/src/commands/index/restore.ts
+++ b/src/commands/index/restore.ts
@@ -43,7 +43,7 @@ export default class IndexRestore extends Kommand {
 
     const index = userFlags.index
 
-    const sdk = new KuzzleSDK({ refreshLogin: true, ...userFlags })
+    const sdk = new KuzzleSDK({ loginTTL: true, ...userFlags })
 
     await sdk.init(this.log)
 

--- a/src/commands/vault/test.ts
+++ b/src/commands/vault/test.ts
@@ -1,0 +1,47 @@
+import { Kommand } from '../../common'
+import { flags } from '@oclif/command'
+import * as _ from 'lodash'
+import chalk from 'chalk'
+
+const Vault = require('kuzzle-vault')
+
+export class VaultTest extends Kommand {
+  static description = 'Tests if an encrypted secrets file can be decrypted.'
+
+  static flags = {
+    'vault-key': flags.string({
+      description: 'Kuzzle Vault Key (or KUZZLE_VAULT_KEY)',
+      default: process.env.KUZZLE_VAULT_KEY,
+    }),
+  }
+
+  static args = [
+    { name: 'secrets-file', description: 'Encrypted secrets file', required: true }
+  ]
+
+  async run() {
+    this.printCommand()
+
+    const { args, flags: userFlags } = this.parse(VaultTest)
+
+    if (_.isEmpty(userFlags['vault-key'])) {
+      this.log(chalk.red('A vault key must be provided'))
+      return
+    }
+
+    if (_.isEmpty(args['secrets-file'])) {
+      this.log(chalk.red('A secrets file must be provided'))
+      return
+    }
+
+    const vault = new Vault(userFlags['vault-key'], null, args['secrets-file'])
+
+    try {
+      vault.decrypt(args['secrets-file'])
+      this.log(chalk.green(`[✔] Secrets file can be decrypted`))
+    }
+    catch (error) {
+      this.log(chalk.red(`[X] Secrets file cannot be decrypted`))
+    }
+  }
+}

--- a/src/commands/vault/test.ts
+++ b/src/commands/vault/test.ts
@@ -38,10 +38,10 @@ export class VaultTest extends Kommand {
 
     try {
       vault.decrypt(args['secrets-file'])
-      this.log(chalk.green(`[✔] Secrets file can be decrypted`))
+      this.log(chalk.green('[✔] Secrets file can be decrypted'))
     }
     catch (error) {
-      this.log(chalk.red(`[X] Secrets file cannot be decrypted`))
+      this.log(chalk.red('[X] Secrets file cannot be decrypted'))
     }
   }
 }

--- a/src/support/kuzzle.ts
+++ b/src/support/kuzzle.ts
@@ -43,7 +43,7 @@ export class KuzzleSDK {
 
   private password: string;
 
-  private refreshLogin: boolean;
+  private loginTTL: string;
 
   constructor(options: any) {
     this.host = options.host
@@ -51,7 +51,7 @@ export class KuzzleSDK {
     this.ssl = options.ssl || this.port === 443
     this.username = options.username
     this.password = options.password
-    this.refreshLogin = options.refreshLogin || false
+    this.loginTTL = options.loginTTL || '10s'
   }
 
   public async init(log: any) {
@@ -70,14 +70,8 @@ export class KuzzleSDK {
         password: this.password,
       }
 
-      await this.sdk.auth.login('local', credentials, '2m')
-      log(chalk.green(`[ℹ] Loggued as ${this.username} for 2 minutes. (refresh: ${this.refreshLogin ? 'on' : 'off'})`))
-
-      if (this.refreshLogin) {
-        setInterval(() => {
-          this.sdk.auth.refreshToken({ expiresIn: '2m' })
-        }, ONE_MINUTE)
-      }
+      await this.sdk.auth.login('local', credentials, this.loginTTL)
+      log(chalk.green(`[ℹ] Loggued as ${this.username} for ${this.loginTTL}.`))
     }
   }
 

--- a/src/support/kuzzle.ts
+++ b/src/support/kuzzle.ts
@@ -4,8 +4,6 @@ import chalk from 'chalk'
 // tslint:disable-next-line
 const { Http, Kuzzle } = require('kuzzle-sdk')
 
-const ONE_MINUTE = 1 * 60 * 1000
-
 export const kuzzleFlags = {
   host: flags.string({
     char: 'h',


### PR DESCRIPTION
## What does this PR do?

Adds a command to test if the vault can be decrypted with the provided key

```
USAGE
  $ kourou vault:test SECRETS-FILE

ARGUMENTS
  SECRETS-FILE  Encrypted secrets file

OPTIONS
  --vault-key=vault-key  Kuzzle Vault Key (or KUZZLE_VAULT_KEY)
```


### Other changes

 -use a configurable login TTL for long command (dump & restore) instead of refreshing the token