### PR TITLE
Adds more login time to allow dumping large collections

### DIFF
--- a/src/commands/collection/dump.ts
+++ b/src/commands/collection/dump.ts
@@ -61,6 +61,6 @@ export default class CollectionDump extends Kommand {
       Number(userFlags['batch-size']),
       path)
 
-    this.log(chalk.green(`[✔] Collection ${args.index}:${args.collection.name} dumped`))
+    this.log(chalk.green(`[✔] Collection ${args.index}:${args.collection} dumped`))
   }
 }

--- a/src/support/kuzzle.ts
+++ b/src/support/kuzzle.ts
@@ -65,7 +65,7 @@ export class KuzzleSDK {
         password: this.password,
       }
 
-      await this.sdk.auth.login('local', credentials, '60s')
+      await this.sdk.auth.login('local', credentials, '2h')
     }
   }
 

--- a/src/support/kuzzle.ts
+++ b/src/support/kuzzle.ts
@@ -4,6 +4,8 @@ import chalk from 'chalk'
 // tslint:disable-next-line
 const { Http, Kuzzle } = require('kuzzle-sdk')
 
+const EIGHT_MINUTES = 5 * 60 * 1000;
+
 export const kuzzleFlags = {
   host: flags.string({
     char: 'h',
@@ -65,7 +67,11 @@ export class KuzzleSDK {
         password: this.password,
       }
 
-      await this.sdk.auth.login('local', credentials, '2h')
+      await this.sdk.auth.login('local', credentials, '10m')
+
+      setInterval(() => {
+        this.sdk.auth.refreshToken()
+      }, EIGHT_MINUTES);
     }
   }
 

--- a/src/support/kuzzle.ts
+++ b/src/support/kuzzle.ts
@@ -4,7 +4,7 @@ import chalk from 'chalk'
 // tslint:disable-next-line
 const { Http, Kuzzle } = require('kuzzle-sdk')
 
-const EIGHT_MINUTES = 5 * 60 * 1000;
+const EIGHT_MINUTES = 8 * 60 * 1000
 
 export const kuzzleFlags = {
   host: flags.string({
@@ -71,7 +71,7 @@ export class KuzzleSDK {
 
       setInterval(() => {
         this.sdk.auth.refreshToken()
-      }, EIGHT_MINUTES);
+      }, EIGHT_MINUTES)
     }
   }
 


### PR DESCRIPTION
## What does this PR do?

If the dumping action takes too long, the SDK will not be connected anymore.  
This PR change the token validity to 10 minutes instead of 60 sec.  
The token will also be refreshed after 8 minutes