### PR TITLE
Adds document:search

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ By environment variables:
 * [`kourou collection:restore PATH`](#kourou-collectionrestore-path)
 * [`kourou document:create INDEX COLLECTION`](#kourou-documentcreate-index-collection)
 * [`kourou document:get INDEX COLLECTION ID`](#kourou-documentget-index-collection-id)
+* [`kourou document:search INDEX COLLECTION`](#kourou-documentsearch-index-collection)
 * [`kourou es:get INDEX ID`](#kourou-esget-index-id)
 * [`kourou es:insert INDEX`](#kourou-esinsert-index)
 * [`kourou es:list-index`](#kourou-eslist-index)
@@ -256,6 +257,39 @@ OPTIONS
 ```
 
 _See code: [src/commands/document/get.ts](https://github.com/kuzzleio/kourou/blob/v0.8.0/src/commands/document/get.ts)_
+
+## `kourou document:search INDEX COLLECTION`
+
+Searches for documents
+
+```
+USAGE
+  $ kourou document:search INDEX COLLECTION
+
+ARGUMENTS
+  INDEX       Index name
+  COLLECTION  Collection name
+
+OPTIONS
+  -h, --host=host      [default: localhost] Kuzzle server host
+  -p, --port=port      [default: 7512] Kuzzle server port
+  --editor             Open an editor (EDITOR env variable) to edit the request before sending
+  --from=from          Optional offset
+  --help               show CLI help
+  --password=password  Kuzzle user password
+  --query=query        [default: {}] Query in JS or JSON format.
+  --scroll=scroll      Optional scroll TTL
+  --size=size          Optional page size
+  --sort=sort          [default: {}] Sort in JS or JSON format.
+  --ssl                Use SSL to connect to Kuzzle
+  --username=username  [default: anonymous] Kuzzle username (local strategy)
+
+EXAMPLES
+  kourou document:search iot sensors --query '{ term: { name: "corona" } }'
+  kourou document:search iot sensors --editor
+```
+
+_See code: [src/commands/document/search.ts](https://github.com/kuzzleio/kourou/blob/v0.8.0/src/commands/document/search.ts)_
 
 ## `kourou es:get INDEX ID`
 
@@ -472,6 +506,7 @@ OPTIONS
   -h, --host=host      [default: localhost] Kuzzle server host
   -p, --port=port      [default: 7512] Kuzzle server port
   --body=body          [default: {}] Request body in JS or JSON format. Will be read from STDIN if available.
+  --editor             Open an editor (EDITOR env variable) to edit the request before sending
   --help               show CLI help
   --password=password  Kuzzle user password
   --ssl                Use SSL to connect to Kuzzle

--- a/features/Document.feature
+++ b/features/Document.feature
@@ -21,7 +21,6 @@ Feature: Document Management
     Then The document "chuon-chuon-kim" content match:
       | my | "other name" |
 
-
   # document:get ===============================================================
 
   @mappings
@@ -35,3 +34,20 @@ Feature: Document Management
       | "yellow-taxi"     |
       | "chuon-chuon-kim" |
     Then I should match stdout with "chuon-chuon-kim"
+
+  # document:search ============================================================
+
+  @mappings
+  Scenario: Searches for documents
+    Given an existing collection "nyc-open-data":"yellow-taxi"
+    And I create the following document:
+      | body | { "name": "Adrien", "city": "Saigon" } |
+    And I create the following document:
+      | body | { "name": "Sebastien", "city": "Cassis" } |
+    And I refresh the collection
+    When I run the command "document:search" with:
+      | arg  | nyc-open-data |                              |
+      | arg  | yellow-taxi   |                              |
+      | flag | --query       | { term: { city: "Saigon" } } |
+    Then I should match stdout with "Adrien"
+    And I should not match stdout with "Sebastien"

--- a/features/support/hooks.js
+++ b/features/support/hooks.js
@@ -32,6 +32,8 @@ async function resetSecurityDefault(sdk) {
 // Common hooks ================================================================
 
 BeforeAll(({ timeout: 10 * 1000 }), async function () {
+  process.env.NODE_ENV = 'test';
+
   const world = new World({});
 
   console.log(`Start tests with ${world.protocol.toLocaleUpperCase()} protocol.`);

--- a/package-lock.json
+++ b/package-lock.json
@@ -3820,11 +3820,6 @@
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
       "integrity": "sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs="
     },
-    "compare-version": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/compare-version/-/compare-version-0.1.2.tgz",
-      "integrity": "sha1-AWLsLZNR9d3VmpICy6k1NmpyUIA="
-    },
     "component-emitter": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.0.tgz",
@@ -10393,7 +10388,6 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.1.0.tgz",
       "integrity": "sha512-J7Z2K08jbGcdA1kkQpJSqLF6T0tdQqpR2pnSUXsIchbPdTI9v3e85cLW0d6WDhwuAleOV71j2xWs8qMPfK7nKw==",
-      "dev": true,
       "requires": {
         "rimraf": "^2.6.3"
       }

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "listr": "^0.14.3",
     "ndjson": "^1.5.0",
     "node-emoji": "^1.10.0",
+    "tmp": "^0.1.0",
     "tslib": "^1.10.0"
   },
   "devDependencies": {

--- a/src/commands/document/create.ts
+++ b/src/commands/document/create.ts
@@ -47,7 +47,11 @@ export default class DocumentCreate extends Kommand {
     const sdk = new KuzzleSDK(userFlags)
     await sdk.init(this.log)
 
-    const body = await this.fromStdin(userFlags.body)
+    const stdin = await this.fromStdin()
+
+    const body = stdin
+      ? stdin
+      : this.parseJs(userFlags.body)
 
     try {
       let document: any

--- a/src/commands/document/create.ts
+++ b/src/commands/document/create.ts
@@ -51,7 +51,7 @@ export default class DocumentCreate extends Kommand {
 
     const body = stdin
       ? stdin
-      : this.parseJs(userFlags.body)
+      : userFlags.body
 
     try {
       let document: any
@@ -61,14 +61,14 @@ export default class DocumentCreate extends Kommand {
           args.index,
           args.collection,
           userFlags.id,
-          body,
+          this.parseJs(body),
           { refresh: 'wait_for' })
       }
       else {
         document = await sdk.document.create(
           args.index,
           args.collection,
-          body,
+          this.parseJs(body),
           userFlags.id,
           { refresh: 'wait_for' })
       }

--- a/src/commands/document/search.ts
+++ b/src/commands/document/search.ts
@@ -72,14 +72,12 @@ export default class DocumentSearch extends Kommand {
       }
     }
 
-    console.log(request)
-    // content from user editor
+    // allow to edit request before send
     if (userFlags.editor) {
       request = this.fromEditor(request, { json: true })
     }
-    console.log(request)
+
     const { result } = await sdk.query(request)
-    console.log(result)
 
     for (const document of result.hits) {
       this.log(chalk.yellow(`Document ID: ${document._id}`))

--- a/src/commands/document/search.ts
+++ b/src/commands/document/search.ts
@@ -1,0 +1,91 @@
+import { flags } from '@oclif/command'
+import { Kommand } from '../../common'
+import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
+import chalk from 'chalk'
+
+export default class DocumentSearch extends Kommand {
+  static description = 'Searches for documents'
+
+  static examples = [
+    'kourou document:search iot sensors --query \'{ term: { name: "corona" } }\'',
+    'kourou document:search iot sensors --editor',
+  ]
+
+  static flags = {
+    query: flags.string({
+      description: 'Query in JS or JSON format.',
+      default: '{}'
+    }),
+    sort: flags.string({
+      description: 'Sort in JS or JSON format.',
+      default: '{}'
+    }),
+    from: flags.string({
+      description: 'Optional offset'
+    }),
+    size: flags.string({
+      description: 'Optional page size',
+    }),
+    scroll: flags.string({
+      description: 'Optional scroll TTL'
+    }),
+    editor: flags.boolean({
+      description: 'Open an editor (EDITOR env variable) to edit the request before sending'
+    }),
+    help: flags.help(),
+    ...kuzzleFlags
+  }
+
+  static args = [
+    { name: 'index', description: 'Index name', required: true },
+    { name: 'collection', description: 'Collection name', required: true }
+  ]
+
+  async run() {
+    try {
+      await this.runSafe()
+    }
+    catch (error) {
+      this.logError(`${error.stack || error.message}\n\tstatus: ${error.status}\n\tid: ${error.id}`)
+    }
+  }
+
+  async runSafe() {
+    this.printCommand()
+
+    const { args, flags: userFlags } = this.parse(DocumentSearch)
+
+    const sdk = new KuzzleSDK(userFlags)
+    await sdk.init(this.log)
+
+    let request: any = {
+      controller: 'document',
+      action: 'search',
+      index: args.index,
+      collection: args.collection,
+      from: userFlags.from,
+      size: userFlags.size,
+      scroll: userFlags.scroll,
+      body: {
+        query: this.parseJs(userFlags.query),
+        sort: this.parseJs(userFlags.sort)
+      }
+    }
+
+    console.log(request)
+    // content from user editor
+    if (userFlags.editor) {
+      request = this.fromEditor(request, { json: true })
+    }
+    console.log(request)
+    const { result } = await sdk.query(request)
+    console.log(result)
+
+    for (const document of result.hits) {
+      this.log(chalk.yellow(`Document ID: ${document._id}`))
+      this.log(`Content: ${JSON.stringify(document._source, null, 2)}`)
+    }
+
+    this.log(chalk.green(`${result.hits.length} documents fetched on a total of ${result.total}`))
+  }
+}

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -2,10 +2,6 @@ import { flags } from '@oclif/command'
 import { Kommand } from '../common'
 import { kuzzleFlags, KuzzleSDK } from '../support/kuzzle'
 import chalk from 'chalk'
-import Editor from '../support/editor';
-
-// tslint:disable-next-line
-const { edit } = require("external-editor");
 
 class Query extends Kommand {
   public static description = 'Executes an API query';
@@ -65,10 +61,10 @@ class Query extends Kommand {
     }
 
     // try to read stdin
-    let body = await this.fromStdin()
+    const body = await this.fromStdin()
 
     if (body && userFlags.editor) {
-      throw new Error('Unable to use flag --editor when reading from STDIN');
+      throw new Error('Unable to use flag --editor when reading from STDIN')
     }
 
     let request = {

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -61,11 +61,14 @@ class Query extends Kommand {
     }
 
     // try to read stdin
-    const body = await this.fromStdin()
+    const stdin = await this.fromStdin()
 
-    if (body && userFlags.editor) {
+    if (stdin && userFlags.editor) {
       throw new Error('Unable to use flag --editor when reading from STDIN')
     }
+    const body = stdin
+      ? stdin
+      : userFlags.body
 
     let request = {
       controller,

--- a/src/common.ts
+++ b/src/common.ts
@@ -28,7 +28,7 @@ export abstract class Kommand extends Command {
    *
    * @returns {Promise<String>} Parsed input
    */
-  fromStdin(defaultValue: string) {
+  fromStdin(defaultValue: string): Promise<string> {
     return new Promise(resolve => {
       // cucumber mess with stdin so I have to do this trick
       if (process.env.NODE_ENV === 'test' || process.stdin.isTTY) {
@@ -44,6 +44,6 @@ export abstract class Kommand extends Command {
 
   public _parseInput(input: string) {
     // eslint-disable-next-line no-eval
-    return eval(`var o = ${input}; o`)
+    return JSON.stringify(eval(`var o = ${input}; o`))
   }
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -2,7 +2,7 @@ import { Command } from '@oclif/command'
 import chalk from 'chalk'
 import emoji from 'node-emoji'
 import fs from 'fs'
-import { Editor, IEditorParams } from './support/editor'
+import { Editor, EditorParams } from './support/editor'
 
 export abstract class Kommand extends Command {
   public printCommand() {
@@ -40,7 +40,7 @@ export abstract class Kommand extends Command {
     })
   }
 
-  fromEditor(defaultContent: object | string, options?: IEditorParams) {
+  fromEditor(defaultContent: object | string, options?: EditorParams) {
     let content = defaultContent
 
     if (typeof content !== 'string') {

--- a/src/support/editor.ts
+++ b/src/support/editor.ts
@@ -40,7 +40,7 @@ export class Editor {
       this.tmpFile = tmp.fileSync({ postfix: '.json' })
     }
 
-    fs.writeFileSync(this.tmpFile.name, this._content);
+    fs.writeFileSync(this.tmpFile.name, this._content)
   }
 
   run() {

--- a/src/support/editor.ts
+++ b/src/support/editor.ts
@@ -7,7 +7,7 @@ export interface IEditorParams {
   json?: boolean;
 }
 
-export default class Editor {
+export class Editor {
   private _content: string;
   private tmpFile: string;
   private defaultEditor: string;
@@ -45,7 +45,8 @@ export default class Editor {
 
     const response = spawnSync(
       editor,
-      [this.tmpFile]);
+      [this.tmpFile],
+      { stdio: "inherit" });
 
     if (response.status !== 0) {
       console.error(response.stdout)
@@ -59,11 +60,6 @@ export default class Editor {
   }
 
   get content() {
-    if (this.options.json) {
-      // remove newlines and spaces
-      return JSON.stringify(JSON.parse(this._content))
-    }
-
     return this._content
   }
 

--- a/src/support/editor.ts
+++ b/src/support/editor.ts
@@ -1,0 +1,83 @@
+import fs from 'fs'
+import { spawnSync } from 'child_process'
+
+const CHARSET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+
+export interface IEditorParams {
+  json?: boolean;
+}
+
+export default class Editor {
+  private _content: string;
+  private tmpFile: string;
+  private defaultEditor: string;
+  private options: IEditorParams;
+
+  constructor(content: string = '', options: IEditorParams = {}) {
+    this._content = content
+
+    this.options = options
+
+    this.defaultEditor = /^win/.test(process.platform)
+      ? 'notepad'
+      : 'nano'
+
+    if (this.options.json) {
+      if (this._content.length === 0) {
+        this._content = '{\n\n}'
+      }
+      else {
+        this._content = JSON.stringify(JSON.parse(this._content), null, 2)
+      }
+
+      this.tmpFile = `/tmp/${this._randomString()}.json`
+    }
+    else {
+      this.tmpFile = `/tmp/${this._randomString()}.tmp`
+    }
+
+    this._createTmpFile()
+  }
+
+  run() {
+    process.env.EDITOR = process.env.EDITOR || this.defaultEditor
+    const editor = process.env.EDITOR
+
+    const response = spawnSync(
+      editor,
+      [this.tmpFile]);
+
+    if (response.status !== 0) {
+      console.error(response.stdout)
+      console.error(response.stderr)
+      throw new Error(`Unable to open editor "${editor}": ${response.error}.\nPlease set EDITOR environment variable.`)
+    }
+
+    this._content = fs.readFileSync(this.tmpFile, 'utf8')
+
+    fs.unlinkSync(this.tmpFile)
+  }
+
+  get content() {
+    if (this.options.json) {
+      // remove newlines and spaces
+      return JSON.stringify(JSON.parse(this._content))
+    }
+
+    return this._content
+  }
+
+  _createTmpFile() {
+    fs.writeFileSync(this.tmpFile, this._content, 'utf8');
+  }
+
+  _randomString() {
+    let string = '';
+
+    for (let i = 12; i--;) {
+      string += CHARSET.charAt(Math.floor(Math.random() * CHARSET.length));
+    }
+
+    return string;
+  }
+}

--- a/src/support/editor.ts
+++ b/src/support/editor.ts
@@ -1,24 +1,27 @@
 import fs from 'fs'
 import { spawnSync } from 'child_process'
 
-const CHARSET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789';
+const CHARSET = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789'
 
-export interface IEditorParams {
+export interface EditorParams {
   json?: boolean;
 }
 
 export class Editor {
   private _content: string;
-  private tmpFile: string;
-  private defaultEditor: string;
-  private options: IEditorParams;
 
-  constructor(content: string = '', options: IEditorParams = {}) {
+  private tmpFile: string;
+
+  private defaultEditor: string;
+
+  private options: EditorParams;
+
+  constructor(content = '', options: EditorParams = {}) {
     this._content = content
 
     this.options = options
 
-    this.defaultEditor = /^win/.test(process.platform)
+    this.defaultEditor = process.platform.startsWith('win')
       ? 'notepad'
       : 'nano'
 
@@ -46,10 +49,12 @@ export class Editor {
     const response = spawnSync(
       editor,
       [this.tmpFile],
-      { stdio: "inherit" });
+      { stdio: 'inherit' })
 
     if (response.status !== 0) {
+      // eslint-disable-next-line
       console.error(response.stdout)
+      // eslint-disable-next-line
       console.error(response.stderr)
       throw new Error(`Unable to open editor "${editor}": ${response.error}.\nPlease set EDITOR environment variable.`)
     }
@@ -64,16 +69,16 @@ export class Editor {
   }
 
   _createTmpFile() {
-    fs.writeFileSync(this.tmpFile, this._content, 'utf8');
+    fs.writeFileSync(this.tmpFile, this._content, 'utf8')
   }
 
   _randomString() {
-    let string = '';
+    let string = ''
 
     for (let i = 12; i--;) {
-      string += CHARSET.charAt(Math.floor(Math.random() * CHARSET.length));
+      string += CHARSET.charAt(Math.floor(Math.random() * CHARSET.length))
     }
 
-    return string;
+    return string
   }
 }

--- a/src/support/editor.ts
+++ b/src/support/editor.ts
@@ -37,7 +37,7 @@ export class Editor {
       this.tmpFile = tmp.fileSync({ postfix: '.json' })
     }
     else {
-      this.tmpFile = tmp.fileSync({ postfix: '.json' })
+      this.tmpFile = tmp.fileSync()
     }
 
     fs.writeFileSync(this.tmpFile.name, this._content)


### PR DESCRIPTION
## What does this PR do?

Adds a `document:search` command.  
This command take the `--query` and `--sort`  flags.  
It's also possible to edit the request before being sent to Kuzzle and manually with the `--editor` option.

[![asciicast](https://asciinema.org/a/ZTAdVlEFnmzxFkKmRBWp1HJBS.svg)](https://asciinema.org/a/ZTAdVlEFnmzxFkKmRBWp1HJBS)

```
USAGE
  $ kourou document:search INDEX COLLECTION

ARGUMENTS
  INDEX       Index name
  COLLECTION  Collection name

OPTIONS
  -h, --host=host      [default: localhost] Kuzzle server host
  -p, --port=port      [default: 7512] Kuzzle server port
  --editor             Open an editor (EDITOR env variable) to edit the request before sending
  --from=from          Optional offset
  --help               show CLI help
  --password=password  Kuzzle user password
  --query=query        [default: {}] Query in JS or JSON format.
  --scroll=scroll      Optional scroll TTL
  --size=size          Optional page size
  --sort=sort          [default: {}] Sort in JS or JSON format.
  --ssl                Use SSL to connect to Kuzzle
  --username=username  [default: anonymous] Kuzzle username (local strategy)

EXAMPLES
  kourou document:search iot sensors --query '{ term: { name: "corona" } }'
  kourou document:search iot sensors --editor
```
### Other changes

 - also allow kourou query to be edited with `--editor` flag

