### PR TITLE
Make vault:test exit with code 1 in case of failure

### DIFF
--- a/src/commands/vault/test.ts
+++ b/src/commands/vault/test.ts
@@ -42,6 +42,7 @@ export class VaultTest extends Kommand {
     }
     catch (error) {
       this.log(chalk.red('[X] Secrets file cannot be decrypted'))
+      throw error
     }
   }
 }


### PR DESCRIPTION
## What does this PR do?
The current `vault:test` is that it always ends with an error code 0. This PR fixes this by throwing the catched exception to make the program exit with error code 1.

### How should this be manually tested?
Before this fix:
```
$ kourou vault:test someSecretsFile --vault-key someBadKey
$ echo $?
0
```
Now:
```
$ kourou vault:test someSecretsFile --vault-key someBadKey
$ echo $?
1
```