### PR TITLE
Rename dump/restore to export/import

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,23 +60,23 @@ By environment variables:
 * [`kourou api-key:create USER`](#kourou-api-keycreate-user)
 * [`kourou api-key:delete USER`](#kourou-api-keydelete-user)
 * [`kourou api-key:search USER`](#kourou-api-keysearch-user)
-* [`kourou collection:dump INDEX COLLECTION`](#kourou-collectiondump-index-collection)
-* [`kourou collection:restore PATH`](#kourou-collectionrestore-path)
+* [`kourou collection:export INDEX COLLECTION`](#kourou-collectionexport-index-collection)
+* [`kourou collection:import PATH`](#kourou-collectionimport-path)
 * [`kourou document:create INDEX COLLECTION`](#kourou-documentcreate-index-collection)
 * [`kourou document:get INDEX COLLECTION ID`](#kourou-documentget-index-collection-id)
 * [`kourou es:get INDEX ID`](#kourou-esget-index-id)
 * [`kourou es:insert INDEX`](#kourou-esinsert-index)
 * [`kourou es:list-index`](#kourou-eslist-index)
 * [`kourou help [COMMAND]`](#kourou-help-command)
-* [`kourou index:dump INDEX`](#kourou-indexdump-index)
-* [`kourou index:restore PATH`](#kourou-indexrestore-path)
+* [`kourou index:export INDEX`](#kourou-indexexport-index)
+* [`kourou index:import PATH`](#kourou-indeximport-path)
 * [`kourou instance:logs`](#kourou-instancelogs)
 * [`kourou instance:spawn`](#kourou-instancespawn)
-* [`kourou profile:dump`](#kourou-profiledump)
-* [`kourou profile:restore PATH`](#kourou-profilerestore-path)
+* [`kourou profile:export`](#kourou-profileexport)
+* [`kourou profile:import PATH`](#kourou-profileimport-path)
 * [`kourou query CONTROLLER:ACTION`](#kourou-query-controlleraction)
-* [`kourou role:dump`](#kourou-roledump)
-* [`kourou role:restore PATH`](#kourou-rolerestore-path)
+* [`kourou role:export`](#kourou-roleexport)
+* [`kourou role:import PATH`](#kourou-roleimport-path)
 * [`kourou vault:add SECRETS-FILE KEY VALUE`](#kourou-vaultadd-secrets-file-key-value)
 * [`kourou vault:encrypt FILE`](#kourou-vaultencrypt-file)
 * [`kourou vault:show SECRETS-FILE KEY`](#kourou-vaultshow-secrets-file-key)
@@ -152,13 +152,13 @@ OPTIONS
 
 _See code: [src/commands/api-key/search.ts](https://github.com/kuzzleio/kourou/blob/v0.8.0/src/commands/api-key/search.ts)_
 
-## `kourou collection:dump INDEX COLLECTION`
+## `kourou collection:export INDEX COLLECTION`
 
-Dump an entire collection content (JSONL format)
+Exports an collection (JSONL format)
 
 ```
 USAGE
-  $ kourou collection:dump INDEX COLLECTION
+  $ kourou collection:export INDEX COLLECTION
 
 ARGUMENTS
   INDEX       Index name
@@ -175,15 +175,15 @@ OPTIONS
   --username=username      [default: anonymous] Kuzzle username (local strategy)
 ```
 
-_See code: [src/commands/collection/dump.ts](https://github.com/kuzzleio/kourou/blob/v0.8.0/src/commands/collection/dump.ts)_
+_See code: [src/commands/collection/export.ts](https://github.com/kuzzleio/kourou/blob/v0.8.0/src/commands/collection/export.ts)_
 
-## `kourou collection:restore PATH`
+## `kourou collection:import PATH`
 
-Restore the content of a previously dumped collection
+Imports a collection
 
 ```
 USAGE
-  $ kourou collection:restore PATH
+  $ kourou collection:import PATH
 
 ARGUMENTS
   PATH  Dump directory path
@@ -201,7 +201,7 @@ OPTIONS
   --username=username      [default: anonymous] Kuzzle username (local strategy)
 ```
 
-_See code: [src/commands/collection/restore.ts](https://github.com/kuzzleio/kourou/blob/v0.8.0/src/commands/collection/restore.ts)_
+_See code: [src/commands/collection/import.ts](https://github.com/kuzzleio/kourou/blob/v0.8.0/src/commands/collection/import.ts)_
 
 ## `kourou document:create INDEX COLLECTION`
 
@@ -332,13 +332,13 @@ OPTIONS
 
 _See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.2.3/src/commands/help.ts)_
 
-## `kourou index:dump INDEX`
+## `kourou index:export INDEX`
 
-Dump an entire index content (JSONL format)
+Exports an index (JSONL format)
 
 ```
 USAGE
-  $ kourou index:dump INDEX
+  $ kourou index:export INDEX
 
 ARGUMENTS
   INDEX  Index name
@@ -354,15 +354,15 @@ OPTIONS
   --username=username      [default: anonymous] Kuzzle username (local strategy)
 ```
 
-_See code: [src/commands/index/dump.ts](https://github.com/kuzzleio/kourou/blob/v0.8.0/src/commands/index/dump.ts)_
+_See code: [src/commands/index/export.ts](https://github.com/kuzzleio/kourou/blob/v0.8.0/src/commands/index/export.ts)_
 
-## `kourou index:restore PATH`
+## `kourou index:import PATH`
 
-Restore the content of a previously dumped index
+Imports an index
 
 ```
 USAGE
-  $ kourou index:restore PATH
+  $ kourou index:import PATH
 
 ARGUMENTS
   PATH  Dump directory or file
@@ -379,7 +379,7 @@ OPTIONS
   --username=username      [default: anonymous] Kuzzle username (local strategy)
 ```
 
-_See code: [src/commands/index/restore.ts](https://github.com/kuzzleio/kourou/blob/v0.8.0/src/commands/index/restore.ts)_
+_See code: [src/commands/index/import.ts](https://github.com/kuzzleio/kourou/blob/v0.8.0/src/commands/index/import.ts)_
 
 ## `kourou instance:logs`
 
@@ -412,13 +412,13 @@ OPTIONS
 
 _See code: [src/commands/instance/spawn.ts](https://github.com/kuzzleio/kourou/blob/v0.8.0/src/commands/instance/spawn.ts)_
 
-## `kourou profile:dump`
+## `kourou profile:export`
 
-Dumps Kuzzle profiles
+Exports profiles
 
 ```
 USAGE
-  $ kourou profile:dump
+  $ kourou profile:export
 
 OPTIONS
   -h, --host=host          [default: localhost] Kuzzle server host
@@ -431,30 +431,29 @@ OPTIONS
   --username=username      [default: anonymous] Kuzzle username (local strategy)
 ```
 
-_See code: [src/commands/profile/dump.ts](https://github.com/kuzzleio/kourou/blob/v0.8.0/src/commands/profile/dump.ts)_
+_See code: [src/commands/profile/export.ts](https://github.com/kuzzleio/kourou/blob/v0.8.0/src/commands/profile/export.ts)_
 
-## `kourou profile:restore PATH`
+## `kourou profile:import PATH`
 
-Restores previously dumped Kuzzle profiles
+Imports profiles
 
 ```
 USAGE
-  $ kourou profile:restore PATH
+  $ kourou profile:import PATH
 
 ARGUMENTS
   PATH  Dump file
 
 OPTIONS
-  -h, --host=host          [default: localhost] Kuzzle server host
-  -p, --port=port          [default: 7512] Kuzzle server port
-  --batch-size=batch-size  [default: 200] Maximum batch size (see limits.documentsWriteCount config)
-  --help                   show CLI help
-  --password=password      Kuzzle user password
-  --ssl                    Use SSL to connect to Kuzzle
-  --username=username      [default: anonymous] Kuzzle username (local strategy)
+  -h, --host=host      [default: localhost] Kuzzle server host
+  -p, --port=port      [default: 7512] Kuzzle server port
+  --help               show CLI help
+  --password=password  Kuzzle user password
+  --ssl                Use SSL to connect to Kuzzle
+  --username=username  [default: anonymous] Kuzzle username (local strategy)
 ```
 
-_See code: [src/commands/profile/restore.ts](https://github.com/kuzzleio/kourou/blob/v0.8.0/src/commands/profile/restore.ts)_
+_See code: [src/commands/profile/import.ts](https://github.com/kuzzleio/kourou/blob/v0.8.0/src/commands/profile/import.ts)_
 
 ## `kourou query CONTROLLER:ACTION`
 
@@ -486,13 +485,13 @@ EXAMPLES
 
 _See code: [src/commands/query.ts](https://github.com/kuzzleio/kourou/blob/v0.8.0/src/commands/query.ts)_
 
-## `kourou role:dump`
+## `kourou role:export`
 
-Dumps Kuzzle roles
+Exports roles
 
 ```
 USAGE
-  $ kourou role:dump
+  $ kourou role:export
 
 OPTIONS
   -h, --host=host          [default: localhost] Kuzzle server host
@@ -505,30 +504,29 @@ OPTIONS
   --username=username      [default: anonymous] Kuzzle username (local strategy)
 ```
 
-_See code: [src/commands/role/dump.ts](https://github.com/kuzzleio/kourou/blob/v0.8.0/src/commands/role/dump.ts)_
+_See code: [src/commands/role/export.ts](https://github.com/kuzzleio/kourou/blob/v0.8.0/src/commands/role/export.ts)_
 
-## `kourou role:restore PATH`
+## `kourou role:import PATH`
 
-Restores previously dumped Kuzzle roles
+Import roles
 
 ```
 USAGE
-  $ kourou role:restore PATH
+  $ kourou role:import PATH
 
 ARGUMENTS
   PATH  Dump file
 
 OPTIONS
-  -h, --host=host          [default: localhost] Kuzzle server host
-  -p, --port=port          [default: 7512] Kuzzle server port
-  --batch-size=batch-size  [default: 200] Maximum batch size (see limits.documentsWriteCount config)
-  --help                   show CLI help
-  --password=password      Kuzzle user password
-  --ssl                    Use SSL to connect to Kuzzle
-  --username=username      [default: anonymous] Kuzzle username (local strategy)
+  -h, --host=host      [default: localhost] Kuzzle server host
+  -p, --port=port      [default: 7512] Kuzzle server port
+  --help               show CLI help
+  --password=password  Kuzzle user password
+  --ssl                Use SSL to connect to Kuzzle
+  --username=username  [default: anonymous] Kuzzle username (local strategy)
 ```
 
-_See code: [src/commands/role/restore.ts](https://github.com/kuzzleio/kourou/blob/v0.8.0/src/commands/role/restore.ts)_
+_See code: [src/commands/role/import.ts](https://github.com/kuzzleio/kourou/blob/v0.8.0/src/commands/role/import.ts)_
 
 ## `kourou vault:add SECRETS-FILE KEY VALUE`
 

--- a/features/Collection.feature
+++ b/features/Collection.feature
@@ -1,21 +1,21 @@
 Feature: Collection Commands
 
   @mappings
-  Scenario: Dump and restore a collection
+  Scenario: Export and import a collection
     Given an existing collection "nyc-open-data":"yellow-taxi"
     And I "create" the following documents:
       | _id               | body                              |
       | "chuon-chuon-kim" | { "city": "hcmc", "district": 1 } |
       | "the-hive"        | { "city": "hcmc", "district": 2 } |
-    # collection:dump
-    When I run the command "collection:dump" with args:
+    # collection:export
+    When I run the command "collection:export" with args:
       | "nyc-open-data" |
       | "yellow-taxi"   |
     Then I successfully call the route "collection":"delete" with args:
       | index      | "nyc-open-data" |
       | collection | "yellow-taxi"   |
-    # collection:restore
-    And I run the command "collection:restore" with args:
+    # collection:import
+    And I run the command "collection:import" with args:
       | "nyc-open-data/yellow-taxi" |
     Then The document "chuon-chuon-kim" content match:
       | city     | "hcmc" |

--- a/features/Index.feature
+++ b/features/Index.feature
@@ -1,7 +1,7 @@
 Feature: Index Commands
 
   @mappings
-  Scenario: Dump and restore an index
+  Scenario: Export and import an index
     Given an existing collection "nyc-open-data":"yellow-taxi"
     And I "create" the following documents:
       | _id               | body                              |
@@ -12,13 +12,13 @@ Feature: Index Commands
       | _id                | body                              |
       | "chuon-chuon-kim2" | { "city": "hcmc", "district": 1 } |
       | "the-hive2"        | { "city": "hcmc", "district": 2 } |
-    # index:dump
-    When I run the command "index:dump" with args:
+    # index:export
+    When I run the command "index:export" with args:
       | "nyc-open-data" |
     And I successfully call the route "index":"delete" with args:
       | index | "nyc-open-data" |
-    # index:restore
-    And I run the command "index:restore" with args:
+    # index:import
+    And I run the command "index:import" with args:
       | "nyc-open-data" |
     Then The document "chuon-chuon-kim2" content match:
       | city     | "hcmc" |

--- a/features/Profile.feature
+++ b/features/Profile.feature
@@ -1,18 +1,18 @@
 Feature: Profile Commands
 
-  # profile:dump & profile:restore
+  # profile:export & profile:import
 
   @security
-  Scenario: Dump and restore profiles
+  Scenario: Export and import profiles
     Given I create a profile "teacher" with the following policies:
       | default | [{ "index": "nyc-open-data" }] |
     And I create a profile "student" with the following policies:
       | admin | [{ "index": "mtp-open-data" }] |
-    When I run the command "profile:dump" with:
+    When I run the command "profile:export" with:
       | flag | --path | ./dump |
     And I delete the profile "teacher"
     And I delete the profile "student"
-    When I run the command "profile:restore" with:
+    When I run the command "profile:import" with:
       | arg | ./dump/profiles.json |  |
     Then The profile "teacher" should match:
       | default | [{ "index": "nyc-open-data" }] |

--- a/features/Role.feature
+++ b/features/Role.feature
@@ -1,18 +1,18 @@
 Feature: Role Commands
 
-  # role:dump & role:restore
+  # role:export & role:import
 
   @security
-  Scenario: Dump and restore roles
+  Scenario: Export and import roles
     Given I create a role "teacher" with the following API rights:
       | document | { "actions": { "create": true } } |
     And I create a role "student" with the following API rights:
       | document | { "actions": { "update": true } } |
-    When I run the command "role:dump" with:
+    When I run the command "role:export" with:
       | flag | --path | ./dump |
     And I delete the role "teacher"
     And I delete the role "student"
-    When I run the command "role:restore" with:
+    When I run the command "role:import" with:
       | arg | ./dump/roles.json |  |
     Then The role "teacher" should match:
       | document | { "actions": { "create": true } } |

--- a/src/commands/collection/export.ts
+++ b/src/commands/collection/export.ts
@@ -6,7 +6,7 @@ import * as fs from 'fs'
 import chalk from 'chalk'
 
 export default class CollectionExport extends Kommand {
-  static description = 'Exports an collection (JSONL format)'
+  static description = 'Exports a collection (JSONL format)'
 
   static flags = {
     help: flags.help({}),

--- a/src/commands/collection/export.ts
+++ b/src/commands/collection/export.ts
@@ -3,16 +3,15 @@ import { Kommand } from '../../common'
 import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
 import { dumpCollectionData, dumpCollectionMappings } from '../../support/dump-collection'
 import * as fs from 'fs'
-import cli from 'cli-ux'
 import chalk from 'chalk'
 
-export default class IndexDump extends Kommand {
-  static description = 'Dump an entire index content (JSONL format)'
+export default class CollectionExport extends Kommand {
+  static description = 'Exports an collection (JSONL format)'
 
   static flags = {
     help: flags.help({}),
     path: flags.string({
-      description: 'Dump directory (default: index name)',
+      description: 'Dump root directory (default: index name)',
     }),
     'batch-size': flags.string({
       description: 'Maximum batch size (see limits.documentsFetchCount config)',
@@ -23,6 +22,7 @@ export default class IndexDump extends Kommand {
 
   static args = [
     { name: 'index', description: 'Index name', required: true },
+    { name: 'collection', description: 'Collection name', required: true },
   ]
 
   async run() {
@@ -37,38 +37,30 @@ export default class IndexDump extends Kommand {
   async runSafe() {
     this.printCommand()
 
-    const { args, flags: userFlags } = this.parse(IndexDump)
+    const { args, flags: userFlags } = this.parse(CollectionExport)
 
     const path = userFlags.path || args.index
 
     const sdk = new KuzzleSDK(userFlags)
     await sdk.init(this.log)
 
-    this.log(chalk.green(`Dumping index "${args.index}" in ${path}/ ...`))
+    this.log(chalk.green(`Dumping collection "${args.index}:${args.collection}" in ${path}/ ...`))
 
     fs.mkdirSync(path, { recursive: true })
 
-    const { collections } = await sdk.collection.list(args.index)
+    await dumpCollectionMappings(
+      sdk,
+      args.index,
+      args.collection,
+      path)
 
-    for (const collection of collections) {
-      if (collection.type !== 'realtime') {
-        await dumpCollectionMappings(
-          sdk,
-          args.index,
-          collection.name,
-          path)
+    await dumpCollectionData(
+      sdk,
+      args.index,
+      args.collection,
+      Number(userFlags['batch-size']),
+      path)
 
-        await dumpCollectionData(
-          sdk,
-          args.index,
-          collection.name,
-          Number(userFlags['batch-size']),
-          path)
-
-        cli.action.stop()
-      }
-    }
-
-    this.log(chalk.green(`[✔] Index ${args.index} dumped`))
+    this.log(chalk.green(`[✔] Collection ${args.index}:${args.collection} dumped`))
   }
 }

--- a/src/commands/collection/import.ts
+++ b/src/commands/collection/import.ts
@@ -4,8 +4,8 @@ import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
 import chalk from 'chalk'
 import { restoreCollectionData, restoreCollectionMappings } from '../../support/restore-collection'
 
-export default class CollectionRestore extends Kommand {
-  static description = 'Restore the content of a previously dumped collection'
+export default class CollectionImport extends Kommand {
+  static description = 'Imports a collection'
 
   static flags = {
     help: flags.help({}),
@@ -41,7 +41,7 @@ export default class CollectionRestore extends Kommand {
   async runSafe() {
     this.printCommand()
 
-    const { args, flags: userFlags } = this.parse(CollectionRestore)
+    const { args, flags: userFlags } = this.parse(CollectionImport)
 
     const index = userFlags.index
     const collection = userFlags.collection

--- a/src/commands/index/export.ts
+++ b/src/commands/index/export.ts
@@ -3,15 +3,16 @@ import { Kommand } from '../../common'
 import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
 import { dumpCollectionData, dumpCollectionMappings } from '../../support/dump-collection'
 import * as fs from 'fs'
+import cli from 'cli-ux'
 import chalk from 'chalk'
 
-export default class CollectionDump extends Kommand {
-  static description = 'Dump an entire collection content (JSONL format)'
+export default class IndexExport extends Kommand {
+  static description = 'Exports an index (JSONL format)'
 
   static flags = {
     help: flags.help({}),
     path: flags.string({
-      description: 'Dump root directory (default: index name)',
+      description: 'Dump directory (default: index name)',
     }),
     'batch-size': flags.string({
       description: 'Maximum batch size (see limits.documentsFetchCount config)',
@@ -22,7 +23,6 @@ export default class CollectionDump extends Kommand {
 
   static args = [
     { name: 'index', description: 'Index name', required: true },
-    { name: 'collection', description: 'Collection name', required: true },
   ]
 
   async run() {
@@ -37,30 +37,38 @@ export default class CollectionDump extends Kommand {
   async runSafe() {
     this.printCommand()
 
-    const { args, flags: userFlags } = this.parse(CollectionDump)
+    const { args, flags: userFlags } = this.parse(IndexExport)
 
     const path = userFlags.path || args.index
 
     const sdk = new KuzzleSDK(userFlags)
     await sdk.init(this.log)
 
-    this.log(chalk.green(`Dumping collection "${args.index}:${args.collection}" in ${path}/ ...`))
+    this.log(chalk.green(`Dumping index "${args.index}" in ${path}/ ...`))
 
     fs.mkdirSync(path, { recursive: true })
 
-    await dumpCollectionMappings(
-      sdk,
-      args.index,
-      args.collection,
-      path)
+    const { collections } = await sdk.collection.list(args.index)
 
-    await dumpCollectionData(
-      sdk,
-      args.index,
-      args.collection,
-      Number(userFlags['batch-size']),
-      path)
+    for (const collection of collections) {
+      if (collection.type !== 'realtime') {
+        await dumpCollectionMappings(
+          sdk,
+          args.index,
+          collection.name,
+          path)
 
-    this.log(chalk.green(`[✔] Collection ${args.index}:${args.collection} dumped`))
+        await dumpCollectionData(
+          sdk,
+          args.index,
+          collection.name,
+          Number(userFlags['batch-size']),
+          path)
+
+        cli.action.stop()
+      }
+    }
+
+    this.log(chalk.green(`[✔] Index ${args.index} dumped`))
   }
 }

--- a/src/commands/index/import.ts
+++ b/src/commands/index/import.ts
@@ -5,8 +5,8 @@ import * as fs from 'fs'
 import chalk from 'chalk'
 import { restoreCollectionData, restoreCollectionMappings } from '../../support/restore-collection'
 
-export default class IndexRestore extends Kommand {
-  static description = 'Restore the content of a previously dumped index'
+export default class IndexImport extends Kommand {
+  static description = 'Imports an index'
 
   static flags = {
     help: flags.help({}),
@@ -39,7 +39,7 @@ export default class IndexRestore extends Kommand {
   async runSafe() {
     this.printCommand()
 
-    const { args, flags: userFlags } = this.parse(IndexRestore)
+    const { args, flags: userFlags } = this.parse(IndexImport)
 
     const index = userFlags.index
 

--- a/src/commands/profile/export.ts
+++ b/src/commands/profile/export.ts
@@ -4,20 +4,20 @@ import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
 import * as fs from 'fs'
 import chalk from 'chalk'
 
-export default class RoleDump extends Kommand {
+export default class ProfileExport extends Kommand {
   private batchSize?: string;
 
   private path?: string;
 
   private sdk?: any;
 
-  static description = 'Dumps Kuzzle roles'
+  static description = 'Exports profiles'
 
   static flags = {
     help: flags.help({}),
     path: flags.string({
       description: 'Dump directory',
-      default: 'roles'
+      default: 'profiles'
     }),
     'batch-size': flags.string({
       description: 'Maximum batch size (see limits.documentsFetchCount config)',
@@ -38,45 +38,45 @@ export default class RoleDump extends Kommand {
   async runSafe() {
     this.printCommand()
 
-    const { flags: userFlags } = this.parse(RoleDump)
+    const { flags: userFlags } = this.parse(ProfileExport)
 
     this.path = userFlags.path
     this.batchSize = userFlags['batch-size']
 
-    const filename = `${this.path}/roles.json`
+    const filename = `${this.path}/profiles.json`
 
     this.sdk = new KuzzleSDK(userFlags)
     await this.sdk.init(this.log)
 
-    this.log(`Dumping roles in ${filename} ...`)
+    this.log(`Dumping securities in ${filename} ...`)
 
     fs.mkdirSync(this.path, { recursive: true })
 
-    const roles = await this._dumpRoles()
+    const profiles = await this._dumpProfiles()
 
-    fs.writeFileSync(filename, JSON.stringify(roles, null, 2))
+    fs.writeFileSync(filename, JSON.stringify(profiles, null, 2))
 
-    this.log(chalk.green(`[✔] ${Object.keys(roles).length} roles dumped`))
+    this.log(chalk.green(`[✔] ${Object.keys(profiles).length} profiles dumped`))
   }
 
-  async _dumpRoles() {
+  async _dumpProfiles() {
     const options = {
       scroll: '10m',
       size: this.batchSize
     }
 
-    let result = await this.sdk.security.searchRoles({}, options)
+    let result = await this.sdk.security.searchProfiles({}, options)
 
-    const roles: any = {}
+    const profiles: any = {}
 
     while (result) {
       result.hits.forEach((hit: any) => {
-        roles[hit._id] = { controllers: hit.controllers }
+        profiles[hit._id] = { policies: hit.policies }
       })
 
       result = await result.next()
     }
 
-    return roles
+    return profiles
   }
 }

--- a/src/commands/profile/import.ts
+++ b/src/commands/profile/import.ts
@@ -4,21 +4,15 @@ import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
 import * as fs from 'fs'
 import chalk from 'chalk'
 
-export default class ProfileRestore extends Kommand {
-  private batchSize?: string;
-
+export default class ProfileImport extends Kommand {
   private path?: string;
 
   private sdk?: any;
 
-  static description = 'Restores previously dumped Kuzzle profiles'
+  static description = 'Imports profiles'
 
   static flags = {
     help: flags.help({}),
-    'batch-size': flags.string({
-      description: 'Maximum batch size (see limits.documentsWriteCount config)',
-      default: '200'
-    }),
     ...kuzzleFlags,
   }
 
@@ -38,10 +32,9 @@ export default class ProfileRestore extends Kommand {
   async runSafe() {
     this.printCommand()
 
-    const { args, flags: userFlags } = this.parse(ProfileRestore)
+    const { args, flags: userFlags } = this.parse(ProfileImport)
 
     this.path = args.path
-    this.batchSize = userFlags['batch-size']
 
     this.sdk = new KuzzleSDK(userFlags)
     await this.sdk.init(this.log)

--- a/src/commands/role/export.ts
+++ b/src/commands/role/export.ts
@@ -4,20 +4,20 @@ import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
 import * as fs from 'fs'
 import chalk from 'chalk'
 
-export default class ProfileDump extends Kommand {
+export default class RoleDump extends Kommand {
   private batchSize?: string;
 
   private path?: string;
 
   private sdk?: any;
 
-  static description = 'Dumps Kuzzle profiles'
+  static description = 'Exports roles'
 
   static flags = {
     help: flags.help({}),
     path: flags.string({
       description: 'Dump directory',
-      default: 'profiles'
+      default: 'roles'
     }),
     'batch-size': flags.string({
       description: 'Maximum batch size (see limits.documentsFetchCount config)',
@@ -38,45 +38,45 @@ export default class ProfileDump extends Kommand {
   async runSafe() {
     this.printCommand()
 
-    const { flags: userFlags } = this.parse(ProfileDump)
+    const { flags: userFlags } = this.parse(RoleDump)
 
     this.path = userFlags.path
     this.batchSize = userFlags['batch-size']
 
-    const filename = `${this.path}/profiles.json`
+    const filename = `${this.path}/roles.json`
 
     this.sdk = new KuzzleSDK(userFlags)
     await this.sdk.init(this.log)
 
-    this.log(`Dumping securities in ${filename} ...`)
+    this.log(`Dumping roles in ${filename} ...`)
 
     fs.mkdirSync(this.path, { recursive: true })
 
-    const profiles = await this._dumpProfiles()
+    const roles = await this._dumpRoles()
 
-    fs.writeFileSync(filename, JSON.stringify(profiles, null, 2))
+    fs.writeFileSync(filename, JSON.stringify(roles, null, 2))
 
-    this.log(chalk.green(`[✔] ${Object.keys(profiles).length} profiles dumped`))
+    this.log(chalk.green(`[✔] ${Object.keys(roles).length} roles dumped`))
   }
 
-  async _dumpProfiles() {
+  async _dumpRoles() {
     const options = {
       scroll: '10m',
       size: this.batchSize
     }
 
-    let result = await this.sdk.security.searchProfiles({}, options)
+    let result = await this.sdk.security.searchRoles({}, options)
 
-    const profiles: any = {}
+    const roles: any = {}
 
     while (result) {
       result.hits.forEach((hit: any) => {
-        profiles[hit._id] = { policies: hit.policies }
+        roles[hit._id] = { controllers: hit.controllers }
       })
 
       result = await result.next()
     }
 
-    return profiles
+    return roles
   }
 }

--- a/src/commands/role/import.ts
+++ b/src/commands/role/import.ts
@@ -4,21 +4,15 @@ import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
 import * as fs from 'fs'
 import chalk from 'chalk'
 
-export default class RoleRestore extends Kommand {
-  private batchSize?: string;
-
+export default class RoleImport extends Kommand {
   private path?: string;
 
   private sdk?: any;
 
-  static description = 'Restores previously dumped Kuzzle roles'
+  static description = 'Import roles'
 
   static flags = {
     help: flags.help({}),
-    'batch-size': flags.string({
-      description: 'Maximum batch size (see limits.documentsWriteCount config)',
-      default: '200'
-    }),
     ...kuzzleFlags,
   }
 
@@ -38,10 +32,9 @@ export default class RoleRestore extends Kommand {
   async runSafe() {
     this.printCommand()
 
-    const { args, flags: userFlags } = this.parse(RoleRestore)
+    const { args, flags: userFlags } = this.parse(RoleImport)
 
     this.path = args.path
-    this.batchSize = userFlags['batch-size']
 
     this.sdk = new KuzzleSDK(userFlags)
     await this.sdk.init(this.log)

--- a/src/common.ts
+++ b/src/common.ts
@@ -17,6 +17,7 @@ export abstract class Kommand extends Command {
   }
 
   public logError(message?: string | undefined, ...args: any[]): void {
+    process.exitCode = 1
     return this.error(chalk.red(message), ...args)
   }
 

--- a/src/support/restore-collection.ts
+++ b/src/support/restore-collection.ts
@@ -51,7 +51,6 @@ export async function restoreCollectionData(sdk: any, log: any, batchSize: numbe
           documents.push(obj)
 
           if (documents.length === batchSize) {
-            console.log({ t: 'batchsize == length' })
             mWriteRequest.body.documents = documents
             documents = []
 


### PR DESCRIPTION
# What does this PR do?

Rename commands:
 - `*:dump` => `*:export`
 - `*:restore` => `*:import`

Eg: `index:dump` => `index:export`

Related to https://github.com/kuzzleio/kuzzle/pull/1587