### PR TITLE
Fix api-key:delete params

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ By environment variables:
 
 <!-- commands -->
 * [`kourou api-key:create USER`](#kourou-api-keycreate-user)
-* [`kourou api-key:delete USER`](#kourou-api-keydelete-user)
+* [`kourou api-key:delete USER ID`](#kourou-api-keydelete-user-id)
 * [`kourou api-key:search USER`](#kourou-api-keysearch-user)
 * [`kourou collection:export INDEX COLLECTION`](#kourou-collectionexport-index-collection)
 * [`kourou collection:import PATH`](#kourou-collectionimport-path)
@@ -108,25 +108,28 @@ OPTIONS
 
 _See code: [src/commands/api-key/create.ts](https://github.com/kuzzleio/kourou/blob/v0.9.0/src/commands/api-key/create.ts)_
 
-## `kourou api-key:delete USER`
+## `kourou api-key:delete USER ID`
 
 Deletes an API key.
 
 ```
 USAGE
-  $ kourou api-key:delete USER
+  $ kourou api-key:delete USER ID
 
 ARGUMENTS
   USER  User kuid
+  ID    API Key unique ID
 
 OPTIONS
   -h, --host=host      [default: localhost] Kuzzle server host
   -p, --port=port      [default: 7512] Kuzzle server port
   --help               show CLI help
-  --id=id              API Key unique ID
   --password=password  Kuzzle user password
   --ssl                Use SSL to connect to Kuzzle
   --username=username  [default: anonymous] Kuzzle username (local strategy)
+
+EXAMPLE
+  kourou vault:delete sigfox-gateway 1k-BF3EBjsXdvA2PR8x
 ```
 
 _See code: [src/commands/api-key/delete.ts](https://github.com/kuzzleio/kourou/blob/v0.9.0/src/commands/api-key/delete.ts)_
@@ -156,7 +159,7 @@ _See code: [src/commands/api-key/search.ts](https://github.com/kuzzleio/kourou/b
 
 ## `kourou collection:export INDEX COLLECTION`
 
-Exports an collection (JSONL format)
+Exports a collection (JSONL format)
 
 ```
 USAGE
@@ -290,7 +293,7 @@ EXAMPLES
   kourou document:search iot sensors --editor
 ```
 
-_See code: [src/commands/document/search.ts](https://github.com/kuzzleio/kourou/blob/v0.8.0/src/commands/document/search.ts)_
+_See code: [src/commands/document/search.ts](https://github.com/kuzzleio/kourou/blob/v0.9.0/src/commands/document/search.ts)_
 
 ## `kourou es:get INDEX ID`
 

--- a/features/ApiKey.feature
+++ b/features/ApiKey.feature
@@ -17,8 +17,8 @@ Feature: Api Key Management
       | _id              | "gordon-key"   |
       | userId           | "gordon"       |
       | body.description | "Test api key" |
-    When I run the command "api-key:delete gordon" with flags:
-      | --id | "gordon-key" |
+    When I run the command "api-key:delete gordon" with:
+      | arg | gordon-key |
     Then I successfully call the route "security":"searchApiKeys" with args:
       | userId | "gordon" |
     And I should receive a empty "hits" array

--- a/src/commands/api-key/delete.ts
+++ b/src/commands/api-key/delete.ts
@@ -7,15 +7,17 @@ class ApiKeyDelete extends Kommand {
 
   public static flags = {
     help: flags.help(),
-    id: flags.string({
-      description: 'API Key unique ID',
-    }),
     ...kuzzleFlags,
   };
 
   static args = [
     { name: 'user', description: 'User kuid', required: true },
+    { name: 'id', description: 'API Key unique ID', required: true },
   ]
+
+  static examples = [
+    'kourou vault:delete sigfox-gateway 1k-BF3EBjsXdvA2PR8x'
+  ];
 
   public async run() {
     try {
@@ -35,9 +37,9 @@ class ApiKeyDelete extends Kommand {
     await sdk.init(this.log)
 
     try {
-      await sdk.security.deleteApiKey(args.user, userFlags.id)
+      await sdk.security.deleteApiKey(args.user, args.id)
 
-      this.log(`Successfully deleted API Key "${userFlags.id}" of user "${args.user}"`)
+      this.log(`Successfully deleted API Key "${args.id}" of user "${args.user}"`)
     } catch (error) {
       this.logError(error.message)
     }

--- a/src/commands/profile/export.ts
+++ b/src/commands/profile/export.ts
@@ -61,7 +61,7 @@ export default class ProfileExport extends Kommand {
 
   async _dumpProfiles() {
     const options = {
-      scroll: '10m',
+      scroll: '10s',
       size: this.batchSize
     }
 

--- a/src/commands/role/export.ts
+++ b/src/commands/role/export.ts
@@ -61,7 +61,7 @@ export default class RoleDump extends Kommand {
 
   async _dumpRoles() {
     const options = {
-      scroll: '10m',
+      scroll: '10s',
       size: this.batchSize
     }
 

--- a/src/support/dump-collection.ts
+++ b/src/support/dump-collection.ts
@@ -11,7 +11,7 @@ export async function dumpCollectionData(sdk: any, index: string, collection: st
   const waitWrite = new Promise(resolve => writeStream.on('finish', resolve))
   const ndjsonStream = ndjson.serialize()
   const options = {
-    scroll: '10m',
+    scroll: '2m',
     size: batchSize
   }
 


### PR DESCRIPTION
## What does this PR do?

Mandatory parameters should be arguments and not flags:
```
# old syntax
$ kourou api-key:delete <user> --id <api key id>

# new syntax
$ kourou api-key:delete <user> <api key id>
```