### PR TITLE
Allows to export only certain document from a collection

### DIFF
--- a/README.md
+++ b/README.md
@@ -173,11 +173,17 @@ OPTIONS
   -h, --host=host          [default: localhost] Kuzzle server host
   -p, --port=port          [default: 7512] Kuzzle server port
   --batch-size=batch-size  [default: 2000] Maximum batch size (see limits.documentsFetchCount config)
+  --editor                 Open an editor (EDITOR env variable) to edit the query before sending
   --help                   show CLI help
   --password=password      Kuzzle user password
   --path=path              Dump root directory (default: index name)
+  --query=query            [default: {}] Only dump documents matching the query (JS or JSON format)
   --ssl                    Use SSL to connect to Kuzzle
   --username=username      [default: anonymous] Kuzzle username (local strategy)
+
+EXAMPLES
+  kourou collection:export nyc-open-data yellow-taxi
+  kourou collection:export nyc-open-data yellow-taxi --query '{ term: { city: "Saigon" } }'
 ```
 
 _See code: [src/commands/collection/export.ts](https://github.com/kuzzleio/kourou/blob/v0.9.0/src/commands/collection/export.ts)_

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ By environment variables:
 
 <!-- commands -->
 * [`kourou api-key:create USER`](#kourou-api-keycreate-user)
-* [`kourou api-key:delete USER`](#kourou-api-keydelete-user)
+* [`kourou api-key:delete USER ID`](#kourou-api-keydelete-user-id)
 * [`kourou api-key:search USER`](#kourou-api-keysearch-user)
 * [`kourou collection:export INDEX COLLECTION`](#kourou-collectionexport-index-collection)
 * [`kourou collection:import PATH`](#kourou-collectionimport-path)
@@ -108,25 +108,28 @@ OPTIONS
 
 _See code: [src/commands/api-key/create.ts](https://github.com/kuzzleio/kourou/blob/v0.9.0/src/commands/api-key/create.ts)_
 
-## `kourou api-key:delete USER`
+## `kourou api-key:delete USER ID`
 
 Deletes an API key.
 
 ```
 USAGE
-  $ kourou api-key:delete USER
+  $ kourou api-key:delete USER ID
 
 ARGUMENTS
   USER  User kuid
+  ID    API Key unique ID
 
 OPTIONS
   -h, --host=host      [default: localhost] Kuzzle server host
   -p, --port=port      [default: 7512] Kuzzle server port
   --help               show CLI help
-  --id=id              API Key unique ID
   --password=password  Kuzzle user password
   --ssl                Use SSL to connect to Kuzzle
   --username=username  [default: anonymous] Kuzzle username (local strategy)
+
+EXAMPLE
+  kourou vault:delete sigfox-gateway 1k-BF3EBjsXdvA2PR8x
 ```
 
 _See code: [src/commands/api-key/delete.ts](https://github.com/kuzzleio/kourou/blob/v0.9.0/src/commands/api-key/delete.ts)_
@@ -156,7 +159,7 @@ _See code: [src/commands/api-key/search.ts](https://github.com/kuzzleio/kourou/b
 
 ## `kourou collection:export INDEX COLLECTION`
 
-Exports an collection (JSONL format)
+Exports a collection (JSONL format)
 
 ```
 USAGE
@@ -290,7 +293,7 @@ EXAMPLES
   kourou document:search iot sensors --editor
 ```
 
-_See code: [src/commands/document/search.ts](https://github.com/kuzzleio/kourou/blob/v0.8.0/src/commands/document/search.ts)_
+_See code: [src/commands/document/search.ts](https://github.com/kuzzleio/kourou/blob/v0.9.0/src/commands/document/search.ts)_
 
 ## `kourou es:get INDEX ID`
 

--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ By environment variables:
 
 <!-- commands -->
 * [`kourou api-key:create USER`](#kourou-api-keycreate-user)
-* [`kourou api-key:delete USER ID`](#kourou-api-keydelete-user-id)
+* [`kourou api-key:delete USER`](#kourou-api-keydelete-user)
 * [`kourou api-key:search USER`](#kourou-api-keysearch-user)
 * [`kourou collection:export INDEX COLLECTION`](#kourou-collectionexport-index-collection)
 * [`kourou collection:import PATH`](#kourou-collectionimport-path)
@@ -108,28 +108,25 @@ OPTIONS
 
 _See code: [src/commands/api-key/create.ts](https://github.com/kuzzleio/kourou/blob/v0.9.0/src/commands/api-key/create.ts)_
 
-## `kourou api-key:delete USER ID`
+## `kourou api-key:delete USER`
 
 Deletes an API key.
 
 ```
 USAGE
-  $ kourou api-key:delete USER ID
+  $ kourou api-key:delete USER
 
 ARGUMENTS
   USER  User kuid
-  ID    API Key unique ID
 
 OPTIONS
   -h, --host=host      [default: localhost] Kuzzle server host
   -p, --port=port      [default: 7512] Kuzzle server port
   --help               show CLI help
+  --id=id              API Key unique ID
   --password=password  Kuzzle user password
   --ssl                Use SSL to connect to Kuzzle
   --username=username  [default: anonymous] Kuzzle username (local strategy)
-
-EXAMPLE
-  kourou vault:delete sigfox-gateway 1k-BF3EBjsXdvA2PR8x
 ```
 
 _See code: [src/commands/api-key/delete.ts](https://github.com/kuzzleio/kourou/blob/v0.9.0/src/commands/api-key/delete.ts)_
@@ -159,7 +156,7 @@ _See code: [src/commands/api-key/search.ts](https://github.com/kuzzleio/kourou/b
 
 ## `kourou collection:export INDEX COLLECTION`
 
-Exports a collection (JSONL format)
+Exports an collection (JSONL format)
 
 ```
 USAGE
@@ -299,7 +296,7 @@ EXAMPLES
   kourou document:search iot sensors --editor
 ```
 
-_See code: [src/commands/document/search.ts](https://github.com/kuzzleio/kourou/blob/v0.9.0/src/commands/document/search.ts)_
+_See code: [src/commands/document/search.ts](https://github.com/kuzzleio/kourou/blob/v0.8.0/src/commands/document/search.ts)_
 
 ## `kourou es:get INDEX ID`
 

--- a/features/Collection.feature
+++ b/features/Collection.feature
@@ -4,13 +4,15 @@ Feature: Collection Commands
   Scenario: Export and import a collection
     Given an existing collection "nyc-open-data":"yellow-taxi"
     And I "create" the following documents:
-      | _id               | body                              |
-      | "chuon-chuon-kim" | { "city": "hcmc", "district": 1 } |
-      | "the-hive"        | { "city": "hcmc", "district": 2 } |
+      | _id               | body                                  |
+      | "chuon-chuon-kim" | { "city": "hcmc", "district": 1 }     |
+      | "the-hive-vn"     | { "city": "hcmc", "district": 2 }     |
+      | "the-hive-th"     | { "city": "changmai", "district": 7 } |
     # collection:export
-    When I run the command "collection:export" with args:
-      | "nyc-open-data" |
-      | "yellow-taxi"   |
+    When I run the command "collection:export" with:
+      | arg  | nyc-open-data |                            |
+      | arg  | yellow-taxi   |                            |
+      | flag | --query       | { term: { city: "hcmc" } } |
     Then I successfully call the route "collection":"delete" with args:
       | index      | "nyc-open-data" |
       | collection | "yellow-taxi"   |
@@ -20,9 +22,10 @@ Feature: Collection Commands
     Then The document "chuon-chuon-kim" content match:
       | city     | "hcmc" |
       | district | 1      |
-    And The document "the-hive" content match:
+    And The document "the-hive-vn" content match:
       | city     | "hcmc" |
       | district | 2      |
+    And The document "the-hive-th" should not exists
     Then I successfully call the route "collection":"getMapping" with args:
       | index      | "nyc-open-data" |
       | collection | "yellow-taxi"   |

--- a/src/commands/api-key/delete.ts
+++ b/src/commands/api-key/delete.ts
@@ -7,17 +7,15 @@ class ApiKeyDelete extends Kommand {
 
   public static flags = {
     help: flags.help(),
+    id: flags.string({
+      description: 'API Key unique ID',
+    }),
     ...kuzzleFlags,
   };
 
   static args = [
     { name: 'user', description: 'User kuid', required: true },
-    { name: 'id', description: 'API Key unique ID', required: true },
   ]
-
-  static examples = [
-    'kourou vault:delete sigfox-gateway 1k-BF3EBjsXdvA2PR8x'
-  ];
 
   public async run() {
     try {
@@ -37,9 +35,9 @@ class ApiKeyDelete extends Kommand {
     await sdk.init(this.log)
 
     try {
-      await sdk.security.deleteApiKey(args.user, args.id)
+      await sdk.security.deleteApiKey(args.user, userFlags.id)
 
-      this.log(`Successfully deleted API Key "${args.id}" of user "${args.user}"`)
+      this.log(`Successfully deleted API Key "${userFlags.id}" of user "${args.user}"`)
     } catch (error) {
       this.logError(error.message)
     }

--- a/src/commands/api-key/delete.ts
+++ b/src/commands/api-key/delete.ts
@@ -7,15 +7,17 @@ class ApiKeyDelete extends Kommand {
 
   public static flags = {
     help: flags.help(),
-    id: flags.string({
-      description: 'API Key unique ID',
-    }),
     ...kuzzleFlags,
   };
 
   static args = [
     { name: 'user', description: 'User kuid', required: true },
+    { name: 'id', description: 'API Key unique ID', required: true },
   ]
+
+  static examples = [
+    'kourou vault:delete sigfox-gateway 1k-BF3EBjsXdvA2PR8x'
+  ];
 
   public async run() {
     try {
@@ -35,9 +37,9 @@ class ApiKeyDelete extends Kommand {
     await sdk.init(this.log)
 
     try {
-      await sdk.security.deleteApiKey(args.user, userFlags.id)
+      await sdk.security.deleteApiKey(args.user, args.id)
 
-      this.log(`Successfully deleted API Key "${userFlags.id}" of user "${args.user}"`)
+      this.log(`Successfully deleted API Key "${args.id}" of user "${args.user}"`)
     } catch (error) {
       this.logError(error.message)
     }

--- a/src/commands/collection/export.ts
+++ b/src/commands/collection/export.ts
@@ -17,12 +17,24 @@ export default class CollectionExport extends Kommand {
       description: 'Maximum batch size (see limits.documentsFetchCount config)',
       default: '2000'
     }),
+    query: flags.string({
+      description: 'Only dump documents matching the query (JS or JSON format)',
+      default: '{}'
+    }),
+    editor: flags.boolean({
+      description: 'Open an editor (EDITOR env variable) to edit the query before sending'
+    }),
     ...kuzzleFlags,
   }
 
   static args = [
     { name: 'index', description: 'Index name', required: true },
     { name: 'collection', description: 'Collection name', required: true },
+  ]
+
+  static examples = [
+    'kourou collection:export nyc-open-data yellow-taxi',
+    'kourou collection:export nyc-open-data yellow-taxi --query \'{ term: { city: "Saigon" } }\'',
   ]
 
   async run() {
@@ -44,7 +56,16 @@ export default class CollectionExport extends Kommand {
     const sdk = new KuzzleSDK({ loginTTL: true, ...userFlags })
     await sdk.init(this.log)
 
-    this.log(chalk.green(`Dumping collection "${args.index}:${args.collection}" in ${path}/ ...`))
+    let query = this.parseJs(userFlags.query)
+
+    if (userFlags.editor) {
+      query = this.fromEditor(query, { json: true })
+    }
+
+    const countAll = await sdk.document.count(args.index, args.collection)
+    const count = await sdk.document.count(args.index, args.collection, { query })
+
+    this.log(`Dumping ${count} of ${countAll} documents from collection "${args.index}:${args.collection}" in ${path}/ ...`)
 
     fs.mkdirSync(path, { recursive: true })
 
@@ -59,7 +80,8 @@ export default class CollectionExport extends Kommand {
       args.index,
       args.collection,
       Number(userFlags['batch-size']),
-      path)
+      path,
+      query)
 
     this.log(chalk.green(`[✔] Collection ${args.index}:${args.collection} dumped`))
   }

--- a/src/support/dump-collection.ts
+++ b/src/support/dump-collection.ts
@@ -4,7 +4,7 @@ import cli from 'cli-ux'
 // tslint:disable-next-line
 const ndjson = require('ndjson')
 
-export async function dumpCollectionData(sdk: any, index: string, collection: string, batchSize: number, path: string) {
+export async function dumpCollectionData(sdk: any, index: string, collection: string, batchSize: number, path: string, query: any = {}) {
   const collectionDir = `${path}/${collection}`
   const filename = `${collectionDir}/documents.jsonl`
   const writeStream = fs.createWriteStream(filename)
@@ -31,7 +31,7 @@ export async function dumpCollectionData(sdk: any, index: string, collection: st
     }
   })
 
-  let results = await sdk.document.search(index, collection, {}, options)
+  let results = await sdk.document.search(index, collection, { query }, options)
 
   const progressBar = cli.progress({
     format: `Dumping ${collection} |{bar}| {percentage}% || {value}/{total} documents`


### PR DESCRIPTION
## What does this PR do?

Allows to give a query to the `collection:export` command to only export document matching the query. 
 
```
$ kourou collection:export nyc-open-data yellow-taxi --query \'{ term: { city: "Saigon" } }\'
$ kourou collection:export nyc-open-data yellow-taxi --editor
```
