### PR TITLE
Add global generic import

### DIFF
--- a/features/Import.feature
+++ b/features/Import.feature
@@ -1,0 +1,79 @@
+Feature: Generic Import
+
+  @mappings
+  @security
+  Scenario: Generic import of dump files
+    # index export
+    Given an existing collection "nyc-open-data":"yellow-taxi"
+    And I "create" the following documents:
+      | _id               | body                              |
+      | "chuon-chuon-kim" | { "city": "hcmc", "district": 1 } |
+      | "the-hive"        | { "city": "hcmc", "district": 2 } |
+    And a collection "nyc-open-data":"green-taxi"
+    And I "create" the following documents:
+      | _id                | body                              |
+      | "chuon-chuon-kim2" | { "city": "hcmc", "district": 1 } |
+      | "the-hive2"        | { "city": "hcmc", "district": 2 } |
+    And I run the command "index:export" with:
+      | arg  | nyc-open-data |        |
+      | flag | --path        | ./dump |
+    And I successfully call the route "index":"delete" with args:
+      | index | "nyc-open-data" |
+
+    # profile export
+    And I create a profile "teacher" with the following policies:
+      | default | [{ "index": "nyc-open-data" }] |
+    And I create a profile "student" with the following policies:
+      | admin | [{ "index": "mtp-open-data" }] |
+    And I run the command "profile:export" with:
+      | flag | --path | ./dump |
+    And I delete the profile "teacher"
+    And I delete the profile "student"
+
+    # role export
+    And I create a role "teacher" with the following API rights:
+      | document | { "actions": { "create": true } } |
+    And I create a role "student" with the following API rights:
+      | document | { "actions": { "update": true } } |
+    When I run the command "role:export" with:
+      | flag | --path | ./dump |
+    And I delete the role "teacher"
+    And I delete the role "student"
+
+
+    # import
+    And I run the command "import" with:
+      | arg | ./dump |  |
+
+    # check index & collections import
+    Then The document "chuon-chuon-kim2" content match:
+      | city     | "hcmc" |
+      | district | 1      |
+    And The document "the-hive2" content match:
+      | city     | "hcmc" |
+      | district | 2      |
+    And an existing collection "nyc-open-data":"yellow-taxi"
+    Then The document "chuon-chuon-kim" content match:
+      | city     | "hcmc" |
+      | district | 1      |
+    And The document "the-hive" content match:
+      | city     | "hcmc" |
+      | district | 2      |
+    Then I successfully call the route "collection":"getMapping" with args:
+      | index      | "nyc-open-data" |
+      | collection | "yellow-taxi"   |
+    And The property "properties" of the result should match:
+      | city | { "type": "keyword" } |
+      | name | { "type": "keyword" } |
+
+    # check role import
+    Then The role "teacher" should match:
+      | document | { "actions": { "create": true } } |
+    And The role "student" should match:
+      | document | { "actions": { "update": true } } |
+
+    # check profile import
+    Then The profile "teacher" should match:
+      | default | [{ "index": "nyc-open-data" }] |
+    And The profile "student" should match:
+      | admin | [{ "index": "mtp-open-data" }] |

--- a/src/commands/collection/import.ts
+++ b/src/commands/collection/import.ts
@@ -1,6 +1,5 @@
 import * as path from 'path'
 import * as fs from 'fs'
-import chalk from 'chalk'
 
 import { flags } from '@oclif/command'
 import { Kommand } from '../../common'

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -1,0 +1,112 @@
+import { flags } from '@oclif/command'
+import * as fs from 'fs'
+import * as path from 'path'
+
+import { Kommand } from '../common'
+import { kuzzleFlags, KuzzleSDK } from '../support/kuzzle'
+import { restoreCollectionData, restoreCollectionMappings } from '../support/restore-collection'
+import { restoreProfiles, restoreRoles } from '../support/restore-securities'
+
+const alphaSort = (a: string, b: string) => {
+  if (a < b) {
+    return 1
+  }
+
+  if (a > b) {
+    return -1
+  }
+
+  return 0
+}
+
+export default class Import extends Kommand {
+  private userFlags: any
+
+  static description = 'Automaticaly imports dump files from a root directory'
+
+  static flags = {
+    help: flags.help({}),
+    'batch-size': flags.string({
+      description: 'Maximum batch size (see limits.documentsWriteCount config)',
+      default: '200'
+    }),
+    ...kuzzleFlags,
+  }
+
+  static args = [
+    { name: 'path', description: 'Root directory containings dumps', required: true },
+  ]
+
+  async runSafe() {
+    this.printCommand()
+
+    const { args, flags: userFlags } = this.parse(Import)
+
+    this.userFlags = userFlags
+
+    this.sdk = new KuzzleSDK({ protocol: 'ws', ...userFlags })
+    await this.sdk.init(this.log)
+
+    await this.walkDirectories(args.path)
+  }
+
+  async walkDirectories(directory: string) {
+    let entries = fs.readdirSync(directory)
+
+    let directories = entries
+      .map(entry => path.join(directory, entry))
+      .filter(dirName => fs.lstatSync(dirName).isDirectory())
+      .sort(alphaSort)
+
+    // Sort files by name some mappings.json come before documents.jsonl
+    let files = entries
+      .map(entry => path.join(directory, entry))
+      .filter(fileName => fs.lstatSync(fileName).isFile())
+      .sort(alphaSort)
+
+    for (const file of files) {
+      await this.importFile(file)
+    }
+
+    for (const dir of directories) {
+      await this.walkDirectories(dir)
+    }
+  }
+
+  async importFile(file: string) {
+    if (file.endsWith('.jsonl')) {
+      this.logInfo(`[collection] Start importing documents in ${file}`)
+      const { total, index, collection } = await restoreCollectionData(
+        this.sdk,
+        this.log.bind(this),
+        Number(this.userFlags['batch-size']),
+        file)
+
+      this.logOk(`[collection] Imported ${total} documents in "${index}":"${collection}"`)
+    }
+    else if (file.endsWith('.json')) {
+      try {
+        const dump = JSON.parse(fs.readFileSync(file, 'utf8'))
+
+        if (dump.type === 'roles') {
+          this.logInfo(`[roles] Start importing roles in ${file}`)
+          const total = await restoreRoles(this.sdk, dump)
+          this.logOk(`[roles] Imported ${total} roles`)
+        }
+        else if (dump.type === 'profiles') {
+          this.logInfo(`[profiles] Start importing profiles in ${file}`)
+          const total = await restoreProfiles(this.sdk, dump)
+          this.logOk(`[profiles] Imported ${total} profiles`)
+        }
+        else if (dump.type === 'mappings') {
+          this.logInfo(`[collection] Start importing mappings in ${file}`)
+          const { index, collection } = await restoreCollectionMappings(this.sdk, dump)
+          this.logOk(`[collection] Imported mappings for "${index}":"${collection}"`)
+        }
+      }
+      catch (error) {
+        this.logKo(`Invalid JSON file "${file}". Import skipped. ${error.message}`)
+      }
+    }
+  }
+}

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -51,15 +51,15 @@ export default class Import extends Kommand {
   }
 
   async walkDirectories(directory: string) {
-    let entries = fs.readdirSync(directory)
+    const entries = fs.readdirSync(directory)
 
-    let directories = entries
+    const directories = entries
       .map(entry => path.join(directory, entry))
       .filter(dirName => fs.lstatSync(dirName).isDirectory())
       .sort(alphaSort)
 
     // Sort files by name some mappings.json come before documents.jsonl
-    let files = entries
+    const files = entries
       .map(entry => path.join(directory, entry))
       .filter(fileName => fs.lstatSync(fileName).isFile())
       .sort(alphaSort)

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -7,7 +7,7 @@ import { kuzzleFlags, KuzzleSDK } from '../support/kuzzle'
 import { restoreCollectionData, restoreCollectionMappings } from '../support/restore-collection'
 import { restoreProfiles, restoreRoles } from '../support/restore-securities'
 
-const alphaSort = (a: string, b: string) => {
+const revAlphaSort = (a: string, b: string) => {
   if (a < b) {
     return 1
   }
@@ -56,13 +56,13 @@ export default class Import extends Kommand {
     const directories = entries
       .map(entry => path.join(directory, entry))
       .filter(dirName => fs.lstatSync(dirName).isDirectory())
-      .sort(alphaSort)
+      .sort(revAlphaSort)
 
     // Sort files by name some mappings.json come before documents.jsonl
     const files = entries
       .map(entry => path.join(directory, entry))
       .filter(fileName => fs.lstatSync(fileName).isFile())
-      .sort(alphaSort)
+      .sort(revAlphaSort)
 
     for (const file of files) {
       await this.importFile(file)

--- a/src/commands/profile/export.ts
+++ b/src/commands/profile/export.ts
@@ -38,7 +38,12 @@ export default class ProfileExport extends Kommand {
 
     const profiles = await this._dumpProfiles()
 
-    fs.writeFileSync(filename, JSON.stringify(profiles, null, 2))
+    const dump = {
+      type: 'profiles',
+      content: profiles
+    }
+
+    fs.writeFileSync(filename, JSON.stringify(dump, null, 2))
 
     this.log(chalk.green(`[✔] ${Object.keys(profiles).length} profiles dumped`))
   }

--- a/src/commands/profile/import.ts
+++ b/src/commands/profile/import.ts
@@ -3,6 +3,7 @@ import { Kommand } from '../../common'
 import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
 import * as fs from 'fs'
 import chalk from 'chalk'
+import { restoreProfiles } from '../../support/restore-securities'
 
 export default class ProfileImport extends Kommand {
   private path?: string;
@@ -32,24 +33,10 @@ export default class ProfileImport extends Kommand {
 
     this.log(`Restoring profiles from ${filename} ...`)
 
-    const profiles = JSON.parse(fs.readFileSync(filename, 'utf-8'))
+    const dump = JSON.parse(fs.readFileSync(filename, 'utf-8'))
 
-    await this._restoreRoles(profiles)
+    const count = await restoreProfiles(this.sdk, dump)
 
-    this.log(chalk.green(`[✔] ${Object.keys(profiles).length} profiles restored`))
-  }
-
-  async _restoreRoles(profiles: any) {
-    const promises = Object.entries(profiles).map(([profileId, profile]) => {
-      // f*** you TS
-      if (this.sdk) {
-        return this.sdk.security.createOrReplaceProfile(profileId, profile, { force: true })
-      }
-
-      // never happen
-      return Promise.resolve()
-    })
-
-    await Promise.all(promises)
+    this.log(chalk.green(`[✔] ${count} profiles restored`))
   }
 }

--- a/src/commands/role/export.ts
+++ b/src/commands/role/export.ts
@@ -38,7 +38,12 @@ export default class RoleDump extends Kommand {
 
     const roles = await this._dumpRoles()
 
-    fs.writeFileSync(filename, JSON.stringify(roles, null, 2))
+    const dump = {
+      type: 'roles',
+      content: roles
+    }
+
+    fs.writeFileSync(filename, JSON.stringify(dump, null, 2))
 
     this.log(chalk.green(`[✔] ${Object.keys(roles).length} roles dumped`))
   }

--- a/src/commands/role/import.ts
+++ b/src/commands/role/import.ts
@@ -3,6 +3,7 @@ import { Kommand } from '../../common'
 import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
 import * as fs from 'fs'
 import chalk from 'chalk'
+import { restoreRoles } from '../../support/restore-securities'
 
 export default class RoleImport extends Kommand {
   private path?: string;
@@ -32,20 +33,10 @@ export default class RoleImport extends Kommand {
 
     this.log(`Restoring roles from ${filename} ...`)
 
-    const roles = JSON.parse(fs.readFileSync(filename, 'utf-8'))
+    const dump = JSON.parse(fs.readFileSync(filename, 'utf-8'))
 
-    const promises = Object.entries(roles).map(([roleId, role]) => {
-      // f*** you TS
-      if (this.sdk) {
-        return this.sdk.security.createOrReplaceRole(roleId, role, { force: true })
-      }
+    const count = await restoreRoles(this.sdk, dump)
 
-      // never happen
-      return Promise.resolve()
-    })
-
-    await Promise.all(promises)
-
-    this.log(chalk.green(`[✔] ${Object.keys(roles).length} roles restored`))
+    this.log(chalk.green(`[✔] ${count} roles restored`))
   }
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -25,6 +25,10 @@ export abstract class Kommand extends Command {
     this.log(chalk.green(`[✔] ${message}`), ...args)
   }
 
+  public logInfo(message: string, ...args: any[]): void {
+    this.log(chalk.yellow(`[ℹ] ${message}`), ...args)
+  }
+
   public logKo(message: string, ...args: any[]): void {
     process.exitCode = 1
     this.log(chalk.red(`[X] ${message}`), ...args)

--- a/src/support/dump-collection.ts
+++ b/src/support/dump-collection.ts
@@ -23,7 +23,7 @@ export async function dumpCollectionData(sdk: any, index: string, collection: st
       else {
         ndjsonStream.once('drain', resolve)
       }
-    });
+    })
   }
 
   writeStream.on('error', error => {

--- a/src/support/restore-collection.ts
+++ b/src/support/restore-collection.ts
@@ -158,5 +158,10 @@ export async function restoreCollectionMappings(sdk: any, dump: any, index?: str
     await sdk.index.create(dstIndex)
   }
 
-  return sdk.collection.create(dstIndex, dstCollection, dump.content[srcIndex][srcCollection])
+  await sdk.collection.create(dstIndex, dstCollection, dump.content[srcIndex][srcCollection])
+
+  return {
+    index: dstIndex,
+    collection: dstCollection
+  }
 }

--- a/src/support/restore-securities.ts
+++ b/src/support/restore-securities.ts
@@ -1,0 +1,27 @@
+export async function restoreRoles(sdk: any, dump: any) {
+  if (dump.type !== 'roles') {
+    throw new Error('Dump file does not contains roles definition')
+  }
+
+  const promises = Object.entries(dump.content)
+    .map(([roleId, role]) => (
+      sdk.security.createOrReplaceRole(roleId, role, { force: true })
+    ));
+
+  await Promise.all(promises)
+
+  return promises.length;
+}
+
+export async function restoreProfiles(sdk: any, dump: any) {
+  if (dump.type !== 'profiles') {
+    throw new Error('Dump file does not contains roles definition')
+  }
+
+  const promises = Object.entries(dump.content)
+    .map(([profileId, profile]) => (
+      sdk.security.createOrReplaceProfile(profileId, profile, { force: true })
+    ));
+
+  return promises.length;
+}

--- a/src/support/restore-securities.ts
+++ b/src/support/restore-securities.ts
@@ -6,11 +6,11 @@ export async function restoreRoles(sdk: any, dump: any) {
   const promises = Object.entries(dump.content)
     .map(([roleId, role]) => (
       sdk.security.createOrReplaceRole(roleId, role, { force: true })
-    ));
+    ))
 
   await Promise.all(promises)
 
-  return promises.length;
+  return promises.length
 }
 
 export async function restoreProfiles(sdk: any, dump: any) {
@@ -21,7 +21,7 @@ export async function restoreProfiles(sdk: any, dump: any) {
   const promises = Object.entries(dump.content)
     .map(([profileId, profile]) => (
       sdk.security.createOrReplaceProfile(profileId, profile, { force: true })
-    ));
+    ))
 
-  return promises.length;
+  return promises.length
 }


### PR DESCRIPTION
## What does this PR do?

This PR unify the dump file format by specifying the content type of a dump.  

In this way dump file are totally "autonomous" and Kourou can load them without knowing the dump file type in advance.

Example:
```
tree dump 
dump
├── nyc-open-data
│   ├── green-taxi
│   │   ├── documents.jsonl
│   │   └── mappings.json
│   └── yellow-taxi
│       ├── documents.jsonl
│       └── mappings.json
├── profiles.json
└── roles.json
```

```
$ kourou import ./dump            
 
 🚀 Kourou - Automaticaly imports dump files from a root directory
 
 [ℹ] Connecting to ws://localhost:7512 ...
 [ℹ] [roles] Start importing roles in dump/roles.json
 [✔] [roles] Imported 5 roles
 [ℹ] [profiles] Start importing profiles in dump/profiles.json
 [✔] [profiles] Imported 5 profiles
 [ℹ] [collection] Start importing mappings in dump/nyc-open-data/yellow-taxi/mappings.json
 [✔] [collection] Imported mappings for "nyc-open-data":"yellow-taxi"
 [ℹ] [collection] Start importing documents in dump/nyc-open-data/yellow-taxi/documents.jsonl
 [✔] [collection] Imported 2 documents in "nyc-open-data":"yellow-taxi"
 [ℹ] [collection] Start importing mappings in dump/nyc-open-data/green-taxi/mappings.json
 [✔] [collection] Imported mappings for "nyc-open-data":"green-taxi"
 [ℹ] [collection] Start importing documents in dump/nyc-open-data/green-taxi/documents.jsonl
 [✔] [collection] Imported 2 documents in "nyc-open-data":"green-taxi"
```

### Other changes

 - standardize some log messages