### PR TITLE
Allows to display the entire Vault content

### DIFF
--- a/README.md
+++ b/README.md
@@ -724,7 +724,7 @@ _See code: [src/commands/role/import.ts](https://github.com/kuzzleio/kourou/blob
 
 ## `kourou vault:add SECRETS-FILE KEY VALUE`
 
-Adds an encrypted key to a secrets file (See: https://github.com/kuzzleio/kuzzle-vault/)
+Adds an encrypted key to an encrypted secrets file.
 
 ```
 USAGE
@@ -738,6 +738,15 @@ ARGUMENTS
 OPTIONS
   --vault-key=vault-key  Kuzzle Vault Key (or KUZZLE_VAULT_KEY)
 
+DESCRIPTION
+  Adds an encrypted key to an encrypted secrets file.
+
+  If the secrets file does not exists, it will be created.
+
+  Encrypted secrets are meant to be loaded inside an application with Kuzzle Vault.
+
+  See https://github.com/kuzzleio/kuzzle-vault/ for more informations.
+
 EXAMPLE
   kourou vault:add config/secrets.enc.json aws.s3.keyId b61e267676660c314b006b06 --vault-key <vault-key>
 ```
@@ -746,7 +755,7 @@ _See code: [src/commands/vault/add.ts](https://github.com/kuzzleio/kourou/blob/v
 
 ## `kourou vault:decrypt FILE`
 
-Decrypts an entire secrets file. (see https://github.com/kuzzleio/kuzzle-vault/)
+Decrypts an entire secrets file.
 
 ```
 USAGE
@@ -760,6 +769,13 @@ OPTIONS
   -o, --output-file=output-file  Output file (default: remove ".enc")
   --vault-key=vault-key          Kuzzle Vault Key (or KUZZLE_VAULT_KEY)
 
+DESCRIPTION
+  Decrypts an entire secrets file.
+
+  Decrypted secrets file must NEVER be committed into the repository.
+
+  See https://github.com/kuzzleio/kuzzle-vault/ for more informations
+
 EXAMPLES
   kourou vault:decrypt config/secrets.enc.json --vault-key <vault-key>
   kourou vault:decrypt config/secrets.enc.json -o config/secrets.json --vault-key <vault-key>
@@ -769,7 +785,7 @@ _See code: [src/commands/vault/decrypt.ts](https://github.com/kuzzleio/kourou/bl
 
 ## `kourou vault:encrypt FILE`
 
-Encrypts an entire secrets file. (see https://github.com/kuzzleio/kuzzle-vault/)
+Encrypts an entire secrets file.
 
 ```
 USAGE
@@ -783,6 +799,24 @@ OPTIONS
   -o, --output-file=output-file  Output file (default: <file>.enc.json)
   --vault-key=vault-key          Kuzzle Vault Key (or KUZZLE_VAULT_KEY)
 
+DESCRIPTION
+  Encrypts an entire secrets file.
+
+  The secrets file must be in JSON format and contains only string or objects.
+
+  Example:
+  {
+     aws: {
+       s3: {
+         keyId: 'b61e267676660c314b006b06'
+       }
+     }
+  }
+
+  Encrypted secrets are meant to be loaded inside an application with Kuzzle Vault.
+
+  See https://github.com/kuzzleio/kuzzle-vault/ for more informations.
+
 EXAMPLES
   kourou vault:encrypt config/secrets.json --vault-key <vault-key>
   kourou vault:encrypt config/secrets.json -o config/secrets_prod.enc.json --vault-key <vault-key>
@@ -792,7 +826,7 @@ _See code: [src/commands/vault/encrypt.ts](https://github.com/kuzzleio/kourou/bl
 
 ## `kourou vault:show SECRETS-FILE [KEY]`
 
-Prints an encrypted file content. (see https://github.com/kuzzleio/kuzzle-vault/)
+Prints an encrypted secrets file content.
 
 ```
 USAGE
@@ -806,11 +840,13 @@ OPTIONS
   --vault-key=vault-key  Kuzzle Vault Key (or KUZZLE_VAULT_KEY)
 
 DESCRIPTION
-  Prints an encrypted file content. (see https://github.com/kuzzleio/kuzzle-vault/)
+  Prints an encrypted secrets file content.
 
   This method can display either:
     - the entire content of the secrets file
     - a single key value
+
+  See https://github.com/kuzzleio/kuzzle-vault/ for more informations
 
 EXAMPLES
   kourou vault:show config/secrets.enc.json --vault-key <vault-key>
@@ -821,7 +857,7 @@ _See code: [src/commands/vault/show.ts](https://github.com/kuzzleio/kourou/blob/
 
 ## `kourou vault:test SECRETS-FILE`
 
-Tests if an encrypted secrets file can be decrypted. (see https://github.com/kuzzleio/kuzzle-vault/)
+Tests if an encrypted secrets file can be decrypted.
 
 ```
 USAGE
@@ -832,6 +868,11 @@ ARGUMENTS
 
 OPTIONS
   --vault-key=vault-key  Kuzzle Vault Key (or KUZZLE_VAULT_KEY)
+
+DESCRIPTION
+  Tests if an encrypted secrets file can be decrypted.
+
+  See https://github.com/kuzzleio/kuzzle-vault/ for more informations
 
 EXAMPLE
   kourou vault:test config/secrets.enc.json --vault-key <vault-key>

--- a/README.md
+++ b/README.md
@@ -741,11 +741,11 @@ OPTIONS
 DESCRIPTION
   Adds an encrypted key to an encrypted secrets file.
 
-  If the secrets file does not exists, it will be created.
+  A new secrets file is created if it does not yet exist.
 
   Encrypted secrets are meant to be loaded inside an application with Kuzzle Vault.
 
-  See https://github.com/kuzzleio/kuzzle-vault/ for more informations.
+  See https://github.com/kuzzleio/kuzzle-vault/ for more information.
 
 EXAMPLE
   kourou vault:add config/secrets.enc.json aws.s3.keyId b61e267676660c314b006b06 --vault-key <vault-key>
@@ -774,7 +774,7 @@ DESCRIPTION
 
   Decrypted secrets file must NEVER be committed into the repository.
 
-  See https://github.com/kuzzleio/kuzzle-vault/ for more informations
+  See https://github.com/kuzzleio/kuzzle-vault/ for more information.
 
 EXAMPLES
   kourou vault:decrypt config/secrets.enc.json --vault-key <vault-key>
@@ -802,7 +802,7 @@ OPTIONS
 DESCRIPTION
   Encrypts an entire secrets file.
 
-  The secrets file must be in JSON format and contains only string or objects.
+  The secrets file must be in JSON format and it must contain only strings or objects.
 
   Example:
   {
@@ -815,7 +815,7 @@ DESCRIPTION
 
   Encrypted secrets are meant to be loaded inside an application with Kuzzle Vault.
 
-  See https://github.com/kuzzleio/kuzzle-vault/ for more informations.
+  See https://github.com/kuzzleio/kuzzle-vault/ for more information.
 
 EXAMPLES
   kourou vault:encrypt config/secrets.json --vault-key <vault-key>
@@ -846,7 +846,7 @@ DESCRIPTION
     - the entire content of the secrets file
     - a single key value
 
-  See https://github.com/kuzzleio/kuzzle-vault/ for more informations
+  See https://github.com/kuzzleio/kuzzle-vault/ for more information.
 
 EXAMPLES
   kourou vault:show config/secrets.enc.json --vault-key <vault-key>
@@ -872,7 +872,7 @@ OPTIONS
 DESCRIPTION
   Tests if an encrypted secrets file can be decrypted.
 
-  See https://github.com/kuzzleio/kuzzle-vault/ for more informations
+  See https://github.com/kuzzleio/kuzzle-vault/ for more information.
 
 EXAMPLE
   kourou vault:test config/secrets.enc.json --vault-key <vault-key>

--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ By environment variables:
 * [`kourou vault:add SECRETS-FILE KEY VALUE`](#kourou-vaultadd-secrets-file-key-value)
 * [`kourou vault:decrypt FILE`](#kourou-vaultdecrypt-file)
 * [`kourou vault:encrypt FILE`](#kourou-vaultencrypt-file)
-* [`kourou vault:show SECRETS-FILE KEY`](#kourou-vaultshow-secrets-file-key)
+* [`kourou vault:show SECRETS-FILE [KEY]`](#kourou-vaultshow-secrets-file-key)
 * [`kourou vault:test SECRETS-FILE`](#kourou-vaulttest-secrets-file)
 
 ## `kourou api-key:check TOKEN`
@@ -105,7 +105,7 @@ OPTIONS
   -h, --host=host      [default: localhost] Kuzzle server host
   -p, --port=port      [default: 7512] Kuzzle server port
   --help               show CLI help
-  --password=password  [default: 0szBh8W7dHMI/u2nQRr6RoZbj+KSlty3H6ySPUe8wmY=] Kuzzle user password
+  --password=password  Kuzzle user password
   --ssl                Use SSL to connect to Kuzzle
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 
@@ -133,7 +133,7 @@ OPTIONS
   --expire=expire                [default: -1] API Key validity
   --help                         show CLI help
   --id=id                        API Key unique ID
-  --password=password            [default: 0szBh8W7dHMI/u2nQRr6RoZbj+KSlty3H6ySPUe8wmY=] Kuzzle user password
+  --password=password            Kuzzle user password
   --ssl                          Use SSL to connect to Kuzzle
   --username=username            [default: anonymous] Kuzzle username (local strategy)
 ```
@@ -156,7 +156,7 @@ OPTIONS
   -h, --host=host      [default: localhost] Kuzzle server host
   -p, --port=port      [default: 7512] Kuzzle server port
   --help               show CLI help
-  --password=password  [default: 0szBh8W7dHMI/u2nQRr6RoZbj+KSlty3H6ySPUe8wmY=] Kuzzle user password
+  --password=password  Kuzzle user password
   --ssl                Use SSL to connect to Kuzzle
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 
@@ -182,7 +182,7 @@ OPTIONS
   -p, --port=port      [default: 7512] Kuzzle server port
   --filter=filter      Filter to match the API Key descriptions
   --help               show CLI help
-  --password=password  [default: 0szBh8W7dHMI/u2nQRr6RoZbj+KSlty3H6ySPUe8wmY=] Kuzzle user password
+  --password=password  Kuzzle user password
   --ssl                Use SSL to connect to Kuzzle
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 ```
@@ -210,7 +210,7 @@ OPTIONS
 
   --help               show CLI help
 
-  --password=password  [default: 0szBh8W7dHMI/u2nQRr6RoZbj+KSlty3H6ySPUe8wmY=] Kuzzle user password
+  --password=password  Kuzzle user password
 
   --ssl                Use SSL to connect to Kuzzle
 
@@ -237,7 +237,7 @@ OPTIONS
   --batch-size=batch-size  [default: 2000] Maximum batch size (see limits.documentsFetchCount config)
   --editor                 Open an editor (EDITOR env variable) to edit the query before sending
   --help                   show CLI help
-  --password=password      [default: 0szBh8W7dHMI/u2nQRr6RoZbj+KSlty3H6ySPUe8wmY=] Kuzzle user password
+  --password=password      Kuzzle user password
   --path=path              Dump root directory
   --query=query            [default: {}] Only dump documents matching the query (JS or JSON format)
   --ssl                    Use SSL to connect to Kuzzle
@@ -269,7 +269,7 @@ OPTIONS
   --help                   show CLI help
   --index=index            If set, override the index destination name
   --no-mappings            Skip collection mappings
-  --password=password      [default: 0szBh8W7dHMI/u2nQRr6RoZbj+KSlty3H6ySPUe8wmY=] Kuzzle user password
+  --password=password      Kuzzle user password
   --ssl                    Use SSL to connect to Kuzzle
   --username=username      [default: anonymous] Kuzzle username (local strategy)
 ```
@@ -294,7 +294,7 @@ OPTIONS
   --body=body          [default: {}] Document body in JS or JSON format. Will be read from STDIN if available
   --help               show CLI help
   --id=id              Optional document ID
-  --password=password  [default: 0szBh8W7dHMI/u2nQRr6RoZbj+KSlty3H6ySPUe8wmY=] Kuzzle user password
+  --password=password  Kuzzle user password
   --replace            Replaces the document if it already exists
   --ssl                Use SSL to connect to Kuzzle
   --username=username  [default: anonymous] Kuzzle username (local strategy)
@@ -323,7 +323,7 @@ OPTIONS
   -h, --host=host      [default: localhost] Kuzzle server host
   -p, --port=port      [default: 7512] Kuzzle server port
   --help               show CLI help
-  --password=password  [default: 0szBh8W7dHMI/u2nQRr6RoZbj+KSlty3H6ySPUe8wmY=] Kuzzle user password
+  --password=password  Kuzzle user password
   --ssl                Use SSL to connect to Kuzzle
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 ```
@@ -348,7 +348,7 @@ OPTIONS
   --editor             Open an editor (EDITOR env variable) to edit the request before sending
   --from=from          Optional offset
   --help               show CLI help
-  --password=password  [default: 0szBh8W7dHMI/u2nQRr6RoZbj+KSlty3H6ySPUe8wmY=] Kuzzle user password
+  --password=password  Kuzzle user password
   --query=query        [default: {}] Query in JS or JSON format.
   --scroll=scroll      Optional scroll TTL
   --size=size          Optional page size
@@ -377,7 +377,7 @@ ARGUMENTS
 
 OPTIONS
   -h, --host=host  [default: localhost] Elasticsearch server host
-  -p, --port=port  [default: 7512] Elasticsearch server port
+  -p, --port=port  [default: 9200] Elasticsearch server port
   --help           show CLI help
 ```
 
@@ -396,7 +396,7 @@ ARGUMENTS
 
 OPTIONS
   -h, --host=host  [default: localhost] Elasticsearch server host
-  -p, --port=port  [default: 7512] Elasticsearch server port
+  -p, --port=port  [default: 9200] Elasticsearch server port
   --body=body      [default: {}] Document body in JSON
   --help           show CLI help
   --id=id          Document ID
@@ -415,7 +415,7 @@ USAGE
 OPTIONS
   -g, --grep=grep  Match output with pattern
   -h, --host=host  [default: localhost] Elasticsearch server host
-  -p, --port=port  [default: 7512] Elasticsearch server port
+  -p, --port=port  [default: 9200] Elasticsearch server port
   --help           show CLI help
 ```
 
@@ -435,9 +435,7 @@ ARGUMENTS
 OPTIONS
   -f, --force                    Overwrite the output file if it already exists
   -o, --output-file=output-file  Output file (default: remove ".enc")
-
-  --vault-key=vault-key          [default: ku_local_XuwT9dXvcx9kaLPaW9qb4cGWK7a653XdZ95fJgyJvB] Kuzzle Vault Key (or
-                                 KUZZLE_VAULT_KEY)
+  --vault-key=vault-key          Kuzzle Vault Key (or KUZZLE_VAULT_KEY)
 
 EXAMPLES
   kourou file:decrypt books/cryptonomicon.txt.enc --vault-key <vault-key>
@@ -460,9 +458,7 @@ ARGUMENTS
 OPTIONS
   -f, --force                    Overwrite the output file if it already exists
   -o, --output-file=output-file  Output file (default: <filename>.enc)
-
-  --vault-key=vault-key          [default: ku_local_XuwT9dXvcx9kaLPaW9qb4cGWK7a653XdZ95fJgyJvB] Kuzzle Vault Key (or
-                                 KUZZLE_VAULT_KEY)
+  --vault-key=vault-key          Kuzzle Vault Key (or KUZZLE_VAULT_KEY)
 
 EXAMPLES
   kourou file:encrypt books/cryptonomicon.txt --vault-key <vault-key>
@@ -483,8 +479,7 @@ ARGUMENTS
   FILE  Encrypted file
 
 OPTIONS
-  --vault-key=vault-key  [default: ku_local_XuwT9dXvcx9kaLPaW9qb4cGWK7a653XdZ95fJgyJvB] Kuzzle Vault Key (or
-                         KUZZLE_VAULT_KEY)
+  --vault-key=vault-key  Kuzzle Vault Key (or KUZZLE_VAULT_KEY)
 
 EXAMPLE
   kourou file:test books/cryptonomicon.txt.enc --vault-key <vault-key>
@@ -525,7 +520,7 @@ OPTIONS
   -p, --port=port          [default: 7512] Kuzzle server port
   --batch-size=batch-size  [default: 200] Maximum batch size (see limits.documentsWriteCount config)
   --help                   show CLI help
-  --password=password      [default: 0szBh8W7dHMI/u2nQRr6RoZbj+KSlty3H6ySPUe8wmY=] Kuzzle user password
+  --password=password      Kuzzle user password
   --ssl                    Use SSL to connect to Kuzzle
   --username=username      [default: anonymous] Kuzzle username (local strategy)
 ```
@@ -548,7 +543,7 @@ OPTIONS
   -p, --port=port          [default: 7512] Kuzzle server port
   --batch-size=batch-size  [default: 2000] Maximum batch size (see limits.documentsFetchCount config)
   --help                   show CLI help
-  --password=password      [default: 0szBh8W7dHMI/u2nQRr6RoZbj+KSlty3H6ySPUe8wmY=] Kuzzle user password
+  --password=password      Kuzzle user password
   --path=path              Dump root directory
   --ssl                    Use SSL to connect to Kuzzle
   --username=username      [default: anonymous] Kuzzle username (local strategy)
@@ -574,7 +569,7 @@ OPTIONS
   --help                   show CLI help
   --index=index            If set, override the index destination name
   --no-mappings            Skip collections mappings
-  --password=password      [default: 0szBh8W7dHMI/u2nQRr6RoZbj+KSlty3H6ySPUe8wmY=] Kuzzle user password
+  --password=password      Kuzzle user password
   --ssl                    Use SSL to connect to Kuzzle
   --username=username      [default: anonymous] Kuzzle username (local strategy)
 ```
@@ -624,7 +619,7 @@ OPTIONS
   -h, --host=host      [default: localhost] Kuzzle server host
   -p, --port=port      [default: 7512] Kuzzle server port
   --help               show CLI help
-  --password=password  [default: 0szBh8W7dHMI/u2nQRr6RoZbj+KSlty3H6ySPUe8wmY=] Kuzzle user password
+  --password=password  Kuzzle user password
   --path=path          [default: profiles] Dump directory
   --ssl                Use SSL to connect to Kuzzle
   --username=username  [default: anonymous] Kuzzle username (local strategy)
@@ -647,7 +642,7 @@ OPTIONS
   -h, --host=host      [default: localhost] Kuzzle server host
   -p, --port=port      [default: 7512] Kuzzle server port
   --help               show CLI help
-  --password=password  [default: 0szBh8W7dHMI/u2nQRr6RoZbj+KSlty3H6ySPUe8wmY=] Kuzzle user password
+  --password=password  Kuzzle user password
   --ssl                Use SSL to connect to Kuzzle
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 ```
@@ -672,7 +667,7 @@ OPTIONS
   --body=body          [default: {}] Request body in JS or JSON format. Will be read from STDIN if available.
   --editor             Open an editor (EDITOR env variable) to edit the request before sending
   --help               show CLI help
-  --password=password  [default: 0szBh8W7dHMI/u2nQRr6RoZbj+KSlty3H6ySPUe8wmY=] Kuzzle user password
+  --password=password  Kuzzle user password
   --ssl                Use SSL to connect to Kuzzle
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 
@@ -697,7 +692,7 @@ OPTIONS
   -h, --host=host      [default: localhost] Kuzzle server host
   -p, --port=port      [default: 7512] Kuzzle server port
   --help               show CLI help
-  --password=password  [default: 0szBh8W7dHMI/u2nQRr6RoZbj+KSlty3H6ySPUe8wmY=] Kuzzle user password
+  --password=password  Kuzzle user password
   --path=path          [default: roles] Dump directory
   --ssl                Use SSL to connect to Kuzzle
   --username=username  [default: anonymous] Kuzzle username (local strategy)
@@ -720,7 +715,7 @@ OPTIONS
   -h, --host=host      [default: localhost] Kuzzle server host
   -p, --port=port      [default: 7512] Kuzzle server port
   --help               show CLI help
-  --password=password  [default: 0szBh8W7dHMI/u2nQRr6RoZbj+KSlty3H6ySPUe8wmY=] Kuzzle user password
+  --password=password  Kuzzle user password
   --ssl                Use SSL to connect to Kuzzle
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 ```
@@ -741,8 +736,7 @@ ARGUMENTS
   VALUE         Value to encrypt
 
 OPTIONS
-  --vault-key=vault-key  [default: ku_local_XuwT9dXvcx9kaLPaW9qb4cGWK7a653XdZ95fJgyJvB] Kuzzle Vault Key (or
-                         KUZZLE_VAULT_KEY)
+  --vault-key=vault-key  Kuzzle Vault Key (or KUZZLE_VAULT_KEY)
 
 EXAMPLE
   kourou vault:add config/secrets.enc.json aws.s3.keyId b61e267676660c314b006b06 --vault-key <vault-key>
@@ -764,9 +758,7 @@ ARGUMENTS
 OPTIONS
   -f, --force                    Overwrite the output file if it already exists
   -o, --output-file=output-file  Output file (default: remove ".enc")
-
-  --vault-key=vault-key          [default: ku_local_XuwT9dXvcx9kaLPaW9qb4cGWK7a653XdZ95fJgyJvB] Kuzzle Vault Key (or
-                                 KUZZLE_VAULT_KEY)
+  --vault-key=vault-key          Kuzzle Vault Key (or KUZZLE_VAULT_KEY)
 
 EXAMPLES
   kourou vault:decrypt config/secrets.enc.json --vault-key <vault-key>
@@ -789,9 +781,7 @@ ARGUMENTS
 OPTIONS
   -f, --force                    Overwrite the output file if it already exists
   -o, --output-file=output-file  Output file (default: <file>.enc.json)
-
-  --vault-key=vault-key          [default: ku_local_XuwT9dXvcx9kaLPaW9qb4cGWK7a653XdZ95fJgyJvB] Kuzzle Vault Key (or
-                                 KUZZLE_VAULT_KEY)
+  --vault-key=vault-key          Kuzzle Vault Key (or KUZZLE_VAULT_KEY)
 
 EXAMPLES
   kourou vault:encrypt config/secrets.json --vault-key <vault-key>
@@ -800,23 +790,30 @@ EXAMPLES
 
 _See code: [src/commands/vault/encrypt.ts](https://github.com/kuzzleio/kourou/blob/v0.10.0/src/commands/vault/encrypt.ts)_
 
-## `kourou vault:show SECRETS-FILE KEY`
+## `kourou vault:show SECRETS-FILE [KEY]`
 
-Prints an encrypted key from a secrets file. (see https://github.com/kuzzleio/kuzzle-vault/)
+Prints an encrypted file content. (see https://github.com/kuzzleio/kuzzle-vault/)
 
 ```
 USAGE
-  $ kourou vault:show SECRETS-FILE KEY
+  $ kourou vault:show SECRETS-FILE [KEY]
 
 ARGUMENTS
   SECRETS-FILE  Encrypted secrets file
-  KEY           Path to the key (lodash style)
+  KEY           Path to a key (lodash style)
 
 OPTIONS
-  --vault-key=vault-key  [default: ku_local_XuwT9dXvcx9kaLPaW9qb4cGWK7a653XdZ95fJgyJvB] Kuzzle Vault Key (or
-                         KUZZLE_VAULT_KEY)
+  --vault-key=vault-key  Kuzzle Vault Key (or KUZZLE_VAULT_KEY)
 
-EXAMPLE
+DESCRIPTION
+  Prints an encrypted file content. (see https://github.com/kuzzleio/kuzzle-vault/)
+
+  This method can display either:
+    - the entire content of the secrets file
+    - a single key value
+
+EXAMPLES
+  kourou vault:show config/secrets.enc.json --vault-key <vault-key>
   kourou vault:show config/secrets.enc.json aws.s3.secretKey --vault-key <vault-key>
 ```
 
@@ -834,8 +831,7 @@ ARGUMENTS
   SECRETS-FILE  Encrypted secrets file
 
 OPTIONS
-  --vault-key=vault-key  [default: ku_local_XuwT9dXvcx9kaLPaW9qb4cGWK7a653XdZ95fJgyJvB] Kuzzle Vault Key (or
-                         KUZZLE_VAULT_KEY)
+  --vault-key=vault-key  Kuzzle Vault Key (or KUZZLE_VAULT_KEY)
 
 EXAMPLE
   kourou vault:test config/secrets.enc.json --vault-key <vault-key>

--- a/src/commands/document/search.ts
+++ b/src/commands/document/search.ts
@@ -41,15 +41,6 @@ export default class DocumentSearch extends Kommand {
     { name: 'collection', description: 'Collection name', required: true }
   ]
 
-  async run() {
-    try {
-      await this.runSafe()
-    }
-    catch (error) {
-      this.logError(`${error.stack || error.message}\n\tstatus: ${error.status}\n\tid: ${error.id}`)
-    }
-  }
-
   async runSafe() {
     this.printCommand()
 

--- a/src/commands/vault/add.ts
+++ b/src/commands/vault/add.ts
@@ -6,7 +6,17 @@ import { Cryptonomicon } from 'kuzzle-vault'
 import { Kommand } from '../../common'
 
 export class VaultAdd extends Kommand {
-  static description = 'Adds an encrypted key to a secrets file (See: https://github.com/kuzzleio/kuzzle-vault/)'
+  static shortDescription = 'Adds an encrypted key to an encrypted secrets file.'
+
+  static description = `
+Adds an encrypted key to an encrypted secrets file.
+
+If the secrets file does not exists, it will be created.
+
+Encrypted secrets are meant to be loaded inside an application with Kuzzle Vault.
+
+See https://github.com/kuzzleio/kuzzle-vault/ for more informations.
+`
 
   static examples = [
     'kourou vault:add config/secrets.enc.json aws.s3.keyId b61e267676660c314b006b06 --vault-key <vault-key>'

--- a/src/commands/vault/add.ts
+++ b/src/commands/vault/add.ts
@@ -6,8 +6,6 @@ import { Cryptonomicon } from 'kuzzle-vault'
 import { Kommand } from '../../common'
 
 export class VaultAdd extends Kommand {
-  static shortDescription = 'Adds an encrypted key to an encrypted secrets file.'
-
   static description = `
 Adds an encrypted key to an encrypted secrets file.
 

--- a/src/commands/vault/add.ts
+++ b/src/commands/vault/add.ts
@@ -9,11 +9,11 @@ export class VaultAdd extends Kommand {
   static description = `
 Adds an encrypted key to an encrypted secrets file.
 
-If the secrets file does not exists, it will be created.
+A new secrets file is created if it does not yet exist.
 
 Encrypted secrets are meant to be loaded inside an application with Kuzzle Vault.
 
-See https://github.com/kuzzleio/kuzzle-vault/ for more informations.
+See https://github.com/kuzzleio/kuzzle-vault/ for more information.
 `
 
   static examples = [

--- a/src/commands/vault/decrypt.ts
+++ b/src/commands/vault/decrypt.ts
@@ -11,7 +11,7 @@ Decrypts an entire secrets file.
 
 Decrypted secrets file must NEVER be committed into the repository.
 
-See https://github.com/kuzzleio/kuzzle-vault/ for more informations
+See https://github.com/kuzzleio/kuzzle-vault/ for more information.
 `
 
   static examples = [

--- a/src/commands/vault/decrypt.ts
+++ b/src/commands/vault/decrypt.ts
@@ -6,8 +6,6 @@ import { Cryptonomicon } from 'kuzzle-vault'
 import { Kommand } from '../../common'
 
 export class VaultDecrypt extends Kommand {
-  static shortDescription = 'Decrypts an entire secrets file.'
-
   static description = `
 Decrypts an entire secrets file.
 

--- a/src/commands/vault/decrypt.ts
+++ b/src/commands/vault/decrypt.ts
@@ -6,7 +6,15 @@ import { Cryptonomicon } from 'kuzzle-vault'
 import { Kommand } from '../../common'
 
 export class VaultDecrypt extends Kommand {
-  static description = 'Decrypts an entire secrets file. (see https://github.com/kuzzleio/kuzzle-vault/)'
+  static shortDescription = 'Decrypts an entire secrets file.'
+
+  static description = `
+Decrypts an entire secrets file.
+
+Decrypted secrets file must NEVER be committed into the repository.
+
+See https://github.com/kuzzleio/kuzzle-vault/ for more informations
+`
 
   static examples = [
     'kourou vault:decrypt config/secrets.enc.json --vault-key <vault-key>',

--- a/src/commands/vault/encrypt.ts
+++ b/src/commands/vault/encrypt.ts
@@ -6,7 +6,26 @@ import { Cryptonomicon } from 'kuzzle-vault'
 import { Kommand } from '../../common'
 
 export class VaultEncrypt extends Kommand {
-  static description = 'Encrypts an entire secrets file. (see https://github.com/kuzzleio/kuzzle-vault/)'
+  static shortDescription = 'Encrypts an entire secrets file.'
+
+  static description = `
+Encrypts an entire secrets file.
+
+The secrets file must be in JSON format and contains only string or objects.
+
+Example:
+{
+  aws: {
+    s3: {
+      keyId: 'b61e267676660c314b006b06'
+    }
+  }
+}
+
+Encrypted secrets are meant to be loaded inside an application with Kuzzle Vault.
+
+See https://github.com/kuzzleio/kuzzle-vault/ for more informations.
+`
 
   static examples = [
     'kourou vault:encrypt config/secrets.json --vault-key <vault-key>',

--- a/src/commands/vault/encrypt.ts
+++ b/src/commands/vault/encrypt.ts
@@ -6,8 +6,6 @@ import { Cryptonomicon } from 'kuzzle-vault'
 import { Kommand } from '../../common'
 
 export class VaultEncrypt extends Kommand {
-  static shortDescription = 'Encrypts an entire secrets file.'
-
   static description = `
 Encrypts an entire secrets file.
 

--- a/src/commands/vault/encrypt.ts
+++ b/src/commands/vault/encrypt.ts
@@ -9,7 +9,7 @@ export class VaultEncrypt extends Kommand {
   static description = `
 Encrypts an entire secrets file.
 
-The secrets file must be in JSON format and contains only string or objects.
+The secrets file must be in JSON format and it must contain only strings or objects.
 
 Example:
 {
@@ -22,7 +22,7 @@ Example:
 
 Encrypted secrets are meant to be loaded inside an application with Kuzzle Vault.
 
-See https://github.com/kuzzleio/kuzzle-vault/ for more informations.
+See https://github.com/kuzzleio/kuzzle-vault/ for more information.
 `
 
   static examples = [

--- a/src/commands/vault/show.ts
+++ b/src/commands/vault/show.ts
@@ -7,12 +7,16 @@ import { Cryptonomicon } from 'kuzzle-vault'
 import { Kommand } from '../../common'
 
 export class VaultShow extends Kommand {
+  static shortDescription = 'Prints an encrypted secrets file content.'
+
   static description = `
-Prints an encrypted file content. (see https://github.com/kuzzleio/kuzzle-vault/)
+Prints an encrypted secrets file content.
 
 This method can display either:
  - the entire content of the secrets file
  - a single key value
+
+See https://github.com/kuzzleio/kuzzle-vault/ for more informations
 `
 
   static examples = [

--- a/src/commands/vault/show.ts
+++ b/src/commands/vault/show.ts
@@ -74,9 +74,9 @@ See https://github.com/kuzzleio/kuzzle-vault/ for more informations
       this.log(chalk.green(decryptedValue))
     }
     else {
-      const decryptedSecrets = cryptonomicon.decryptObject(encryptedSecrets);
+      const decryptedSecrets = cryptonomicon.decryptObject(encryptedSecrets)
 
-      this.logOk(`Secrets file content:`)
+      this.logOk('Secrets file content:')
       this.log(chalk.green(JSON.stringify(decryptedSecrets, null, 2)))
     }
   }

--- a/src/commands/vault/show.ts
+++ b/src/commands/vault/show.ts
@@ -14,7 +14,7 @@ This method can display either:
  - the entire content of the secrets file
  - a single key value
 
-See https://github.com/kuzzleio/kuzzle-vault/ for more informations
+See https://github.com/kuzzleio/kuzzle-vault/ for more information.
 `
 
   static examples = [
@@ -65,7 +65,7 @@ See https://github.com/kuzzleio/kuzzle-vault/ for more informations
       const encryptedValue = _.get(encryptedSecrets, args.key)
 
       if (!encryptedValue) {
-        throw new Error(`Key "${args.key}" does not exists`)
+        throw new Error(`Key "${args.key}" does not exist`)
       }
 
       const decryptedValue = cryptonomicon.decryptString(encryptedValue)

--- a/src/commands/vault/show.ts
+++ b/src/commands/vault/show.ts
@@ -7,8 +7,6 @@ import { Cryptonomicon } from 'kuzzle-vault'
 import { Kommand } from '../../common'
 
 export class VaultShow extends Kommand {
-  static shortDescription = 'Prints an encrypted secrets file content.'
-
   static description = `
 Prints an encrypted secrets file content.
 

--- a/src/commands/vault/test.ts
+++ b/src/commands/vault/test.ts
@@ -5,7 +5,13 @@ import { Vault } from 'kuzzle-vault'
 import { Kommand } from '../../common'
 
 export class VaultTest extends Kommand {
-  static description = 'Tests if an encrypted secrets file can be decrypted. (see https://github.com/kuzzleio/kuzzle-vault/)'
+  static shortDescription = 'Tests if an encrypted secrets file can be decrypted.'
+
+  static description = `
+Tests if an encrypted secrets file can be decrypted.
+
+See https://github.com/kuzzleio/kuzzle-vault/ for more informations
+`
 
   static examples = [
     'kourou vault:test config/secrets.enc.json --vault-key <vault-key>'

--- a/src/commands/vault/test.ts
+++ b/src/commands/vault/test.ts
@@ -8,7 +8,7 @@ export class VaultTest extends Kommand {
   static description = `
 Tests if an encrypted secrets file can be decrypted.
 
-See https://github.com/kuzzleio/kuzzle-vault/ for more informations
+See https://github.com/kuzzleio/kuzzle-vault/ for more information.
 `
 
   static examples = [

--- a/src/commands/vault/test.ts
+++ b/src/commands/vault/test.ts
@@ -5,8 +5,6 @@ import { Vault } from 'kuzzle-vault'
 import { Kommand } from '../../common'
 
 export class VaultTest extends Kommand {
-  static shortDescription = 'Tests if an encrypted secrets file can be decrypted.'
-
   static description = `
 Tests if an encrypted secrets file can be decrypted.
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -12,7 +12,9 @@ export abstract class Kommand extends Command {
   public printCommand() {
     const klass: any = this.constructor
 
-    const shortDescription = klass.shortDescription || klass.description
+    const shortDescription = klass.description
+      .split('\n')
+      .filter((line: string) => line.length > 0)[0]
 
     this.log('')
     this.log(`${chalk.blue.bold(`${emoji.get('rocket')} Kourou`)} - ${shortDescription}`)

--- a/src/common.ts
+++ b/src/common.ts
@@ -12,8 +12,10 @@ export abstract class Kommand extends Command {
   public printCommand() {
     const klass: any = this.constructor
 
+    const shortDescription = klass.shortDescription || klass.description
+
     this.log('')
-    this.log(`${chalk.blue.bold(`${emoji.get('rocket')} Kourou`)} - ${klass.description}`)
+    this.log(`${chalk.blue.bold(`${emoji.get('rocket')} Kourou`)} - ${shortDescription}`)
     this.log('')
   }
 


### PR DESCRIPTION
## What does this PR do?

Allows `kourou vault:show` to display an entire Vault content instead of just a key 

### Other changes

 - add better descriptions for Vault commandes
