### PR TITLE
Add command to spot differences between kuzzlerc files

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ By environment variables:
 * [`kourou collection:create INDEX COLLECTION`](#kourou-collectioncreate-index-collection)
 * [`kourou collection:export INDEX COLLECTION`](#kourou-collectionexport-index-collection)
 * [`kourou collection:import PATH`](#kourou-collectionimport-path)
+* [`kourou config:key-diff FIRST SECOND`](#kourou-configkey-diff-first-second)
 * [`kourou document:create INDEX COLLECTION`](#kourou-documentcreate-index-collection)
 * [`kourou document:get INDEX COLLECTION ID`](#kourou-documentget-index-collection-id)
 * [`kourou document:search INDEX COLLECTION`](#kourou-documentsearch-index-collection)
@@ -275,6 +276,27 @@ OPTIONS
 ```
 
 _See code: [src/commands/collection/import.ts](https://github.com/kuzzleio/kourou/blob/v0.11.0/src/commands/collection/import.ts)_
+
+## `kourou config:key-diff FIRST SECOND`
+
+Returns differences between the keys of two Kuzzle configuration files (kuzzlerc)
+
+```
+USAGE
+  $ kourou config:key-diff FIRST SECOND
+
+ARGUMENTS
+  FIRST   First configuration file
+  SECOND  Second configuration file
+
+OPTIONS
+  --strict  Exit with an error if diff are found
+
+EXAMPLE
+  kourou config:key-diff config/local/kuzzlerc config/production/kuzzlerc
+```
+
+_See code: [src/commands/config/key-diff.ts](https://github.com/kuzzleio/kourou/blob/v0.11.0/src/commands/config/key-diff.ts)_
 
 ## `kourou document:create INDEX COLLECTION`
 
@@ -553,8 +575,6 @@ _See code: [src/commands/index/export.ts](https://github.com/kuzzleio/kourou/blo
 
 ## `kourou index:import PATH`
 
-Imports an index
-
 ```
 USAGE
   $ kourou index:import PATH
@@ -572,6 +592,10 @@ OPTIONS
   --password=password      Kuzzle user password
   --ssl                    Use SSL to connect to Kuzzle
   --username=username      [default: anonymous] Kuzzle username (local strategy)
+
+EXAMPLES
+  kourou index:import ./dump/iot-data
+  kourou index:import ./dump/iot-data --index iot-data-production --no-mappings
 ```
 
 _See code: [src/commands/index/import.ts](https://github.com/kuzzleio/kourou/blob/v0.11.0/src/commands/index/import.ts)_

--- a/features/Config.feature
+++ b/features/Config.feature
@@ -1,0 +1,9 @@
+Feature: Config
+
+  # config:key-diff ================================================================
+
+  Scenario: Config key-diff
+    When I run the command "config:key-diff" with:
+      | arg | features/fixtures/kuzzlerc1 |
+      | arg | features/fixtures/kuzzlerc2 |
+    Then I should match stdout with "was removed"

--- a/features/Config.feature
+++ b/features/Config.feature
@@ -1,9 +1,9 @@
 Feature: Config
 
-  # config:key-diff ================================================================
+  # config:diff ================================================================
 
-  Scenario: Config key-diff
-    When I run the command "config:key-diff" with:
+  Scenario: Config diff
+    When I run the command "config:diff" with:
       | arg | features/fixtures/kuzzlerc1 |
       | arg | features/fixtures/kuzzlerc2 |
     Then I should match stdout with "was removed"

--- a/features/fixtures/kuzzlerc1
+++ b/features/fixtures/kuzzlerc1
@@ -1,0 +1,6 @@
+{
+  "s3": {
+    "bucketRegion": "Vietnam",
+    "maxSize": "42KB"
+  }
+}

--- a/features/fixtures/kuzzlerc1
+++ b/features/fixtures/kuzzlerc1
@@ -1,6 +1,7 @@
 {
   "s3": {
     "bucketRegion": "Vietnam",
-    "maxSize": "42KB"
+    "maxSize": "42KB",
+    "name": "hanoi"
   }
 }

--- a/features/fixtures/kuzzlerc2
+++ b/features/fixtures/kuzzlerc2
@@ -1,0 +1,5 @@
+{
+  "s3": {
+    "bucketRegion": "Vietnam"
+  }
+}

--- a/features/fixtures/kuzzlerc2
+++ b/features/fixtures/kuzzlerc2
@@ -1,5 +1,6 @@
 {
   "s3": {
-    "bucketRegion": "Vietnam"
+    "bucketRegion": "Vietnam",
+    "name": "hcmc"
   }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1596,6 +1596,12 @@
           "requires": {
             "ansi-regex": "^3.0.0"
           }
+        },
+        "strip-json-comments": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "dev": true
         }
       }
     },
@@ -4636,10 +4642,9 @@
       "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA=="
     },
     "strip-json-comments": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-      "dev": true
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
+      "integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w=="
     },
     "supports-color": {
       "version": "5.5.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "listr": "^0.14.3",
     "ndjson": "^1.5.0",
     "node-emoji": "^1.10.0",
+    "strip-json-comments": "^3.1.0",
     "tmp": "^0.1.0",
     "tslib": "^1.11.1"
   },

--- a/src/commands/api-key/check.ts
+++ b/src/commands/api-key/check.ts
@@ -19,8 +19,6 @@ class ApiKeyCheck extends Kommand {
   ]
 
   async runSafe() {
-    this.printCommand()
-
     const { args, flags: userFlags } = this.parse(ApiKeyCheck)
 
     this.sdk = new KuzzleSDK(userFlags)

--- a/src/commands/api-key/create.ts
+++ b/src/commands/api-key/create.ts
@@ -27,8 +27,6 @@ class ApiKeyCreate extends Kommand {
   ]
 
   async runSafe() {
-    this.printCommand()
-
     const { args, flags: userFlags } = this.parse(ApiKeyCreate)
 
     this.sdk = new KuzzleSDK(userFlags)

--- a/src/commands/api-key/delete.ts
+++ b/src/commands/api-key/delete.ts
@@ -20,8 +20,6 @@ class ApiKeyDelete extends Kommand {
   ];
 
   async runSafe() {
-    this.printCommand()
-
     const { flags: userFlags, args } = this.parse(ApiKeyDelete)
 
     this.sdk = new KuzzleSDK(userFlags)

--- a/src/commands/api-key/search.ts
+++ b/src/commands/api-key/search.ts
@@ -18,8 +18,6 @@ class ApiKeySearch extends Kommand {
   ]
 
   async runSafe() {
-    this.printCommand()
-
     const { flags: userFlags, args } = this.parse(ApiKeySearch)
 
     this.sdk = new KuzzleSDK(userFlags)

--- a/src/commands/collection/create.ts
+++ b/src/commands/collection/create.ts
@@ -39,6 +39,6 @@ export default class CollectionCreate extends Kommand {
 
     await this.sdk.collection.create(args.index, args.collection, body)
 
-    this.logOk(`Collection "${args.index}":"${args.collection}" has been created`)
+    this.logOk(`Collection "${args.index}":"${args.collection}" created`)
   }
 }

--- a/src/commands/collection/create.ts
+++ b/src/commands/collection/create.ts
@@ -20,8 +20,6 @@ export default class CollectionCreate extends Kommand {
   ]
 
   async runSafe() {
-    this.printCommand()
-
     const { args, flags: userFlags } = this.parse(CollectionCreate)
 
     this.sdk = new KuzzleSDK(userFlags)

--- a/src/commands/collection/export.ts
+++ b/src/commands/collection/export.ts
@@ -38,8 +38,6 @@ export default class CollectionExport extends Kommand {
   ]
 
   async runSafe() {
-    this.printCommand()
-
     const { args, flags: userFlags } = this.parse(CollectionExport)
 
     const path = userFlags.path ? `${userFlags.path}/${args.index}` : args.index

--- a/src/commands/collection/import.ts
+++ b/src/commands/collection/import.ts
@@ -32,8 +32,6 @@ export default class CollectionImport extends Kommand {
   ]
 
   async runSafe() {
-    this.printCommand()
-
     const { args, flags: userFlags } = this.parse(CollectionImport)
 
     const index = userFlags.index

--- a/src/commands/config/diff.ts
+++ b/src/commands/config/diff.ts
@@ -1,0 +1,89 @@
+import { flags } from '@oclif/command'
+import * as _ from 'lodash'
+import * as fs from 'fs'
+import stripComments from 'strip-json-comments'
+
+import { Kommand } from '../../common'
+
+export class ConfigDiff extends Kommand {
+  static description = 'Returns differences between two Kuzzle configuration files (kuzzlerc)'
+
+  static examples = [
+    'kourou config:diff config/local/kuzzlerc config/production/kuzzlerc'
+  ]
+
+  static flags = {
+    strict: flags.boolean({
+      description: 'Exit with an error if diff are found',
+      default: false
+    }),
+  }
+
+  static args = [
+    { name: 'first', description: 'First configuration file', required: true },
+    { name: 'second', description: 'Second configuration file', required: true },
+  ]
+
+  async runSafe() {
+    this.printCommand()
+
+    const { args, flags: userFlags } = this.parse(ConfigDiff)
+
+    if (!fs.existsSync(args.first)) {
+      throw new Error(`File "${args.first}" does not exists`)
+    }
+
+    if (!fs.existsSync(args.second)) {
+      throw new Error(`File "${args.second}" does not exists`)
+    }
+
+    const first = JSON.parse(stripComments(fs.readFileSync(args.first, 'utf8')))
+    const second = JSON.parse(stripComments(fs.readFileSync(args.second, 'utf8')))
+
+    const changes = this._keyChanges(first, second)
+
+    if (_.isEmpty(changes)) {
+      this.logOk('No configuration keys differences between the provided configurations')
+      return
+    }
+
+    this.logInfo('Found key differences between the provided configurations. In the second file:')
+
+    for (const [path, change] of Object.entries(changes)) {
+      this.log(` - key "${path}" was ${change}`)
+    }
+
+    if (userFlags.strict) {
+      throw new Error('Provided configuration contains different keys')
+    }
+  }
+
+  // Returns path who had changed between two objects (inspired by https://gist.github.com/Yimiprod/7ee176597fef230d1451)
+  _keyChanges(base: any, object: any) {
+    const changes: any = {}
+
+    function walkObject(base: any, object: any, path: any = []) {
+      for (const key of Object.keys(base)) {
+        if (object[key] === undefined) {
+          const ar: [] = []
+          const ar2: [] = []
+          ar.concat(ar2)
+          changes[[...path, key].join('.')] = 'removed'
+        }
+      }
+
+      for (const [key, value] of Object.entries(object)) {
+        if (base[key] === undefined) {
+          changes[[...path, key].join('.')] = 'added'
+        }
+        else if (!_.isEqual(value, base[key]) && _.isObject(value) && _.isObject(base[key])) {
+          walkObject(base[key], value, [...path, key])
+        }
+      }
+    }
+
+    walkObject(base, object)
+
+    return changes
+  }
+}

--- a/src/commands/config/diff.ts
+++ b/src/commands/config/diff.ts
@@ -48,7 +48,7 @@ export class ConfigKeyDiff extends Kommand {
     this.logInfo('Found differences between keys in the provided configurations. In the second file:')
 
     for (const [path, change] of Object.entries(changes)) {
-      this.log(` - key "${path}" was ${change}`)
+      this.log(` - key "${path}" ${change}`)
     }
 
     if (userFlags.strict) {
@@ -66,16 +66,19 @@ export class ConfigKeyDiff extends Kommand {
           const ar: [] = []
           const ar2: [] = []
           ar.concat(ar2)
-          changes[[...path, key].join('.')] = 'removed'
+          changes[[...path, key].join('.')] = 'was removed'
         }
       }
 
       for (const [key, value] of Object.entries(object)) {
         if (base[key] === undefined) {
-          changes[[...path, key].join('.')] = 'added'
+          changes[[...path, key].join('.')] = 'was added'
         }
         else if (!_.isEqual(value, base[key]) && _.isObject(value) && _.isObject(base[key])) {
           walkObject(base[key], value, [...path, key])
+        }
+        else if (base[key] !== object[key]) {
+          changes[[...path, key].join('.')] = `value is "${object[key]}" and was "${base[key]}"`;
         }
       }
     }

--- a/src/commands/config/diff.ts
+++ b/src/commands/config/diff.ts
@@ -78,7 +78,7 @@ export class ConfigKeyDiff extends Kommand {
           walkObject(base[key], value, [...path, key])
         }
         else if (base[key] !== object[key]) {
-          changes[[...path, key].join('.')] = `value is "${object[key]}" and was "${base[key]}"`;
+          changes[[...path, key].join('.')] = `value is "${object[key]}" and was "${base[key]}"`
         }
       }
     }

--- a/src/commands/config/diff.ts
+++ b/src/commands/config/diff.ts
@@ -43,11 +43,11 @@ export class ConfigDiff extends Kommand {
     const changes = this._keyChanges(first, second)
 
     if (_.isEmpty(changes)) {
-      this.logOk('No configuration keys differences between the provided configurations')
+      this.logOk('No differences between keys in the provided configurations')
       return
     }
 
-    this.logInfo('Found key differences between the provided configurations. In the second file:')
+    this.logInfo('Found differences between keys in the provided configurations. In the second file:')
 
     for (const [path, change] of Object.entries(changes)) {
       this.log(` - key "${path}" was ${change}`)

--- a/src/commands/config/diff.ts
+++ b/src/commands/config/diff.ts
@@ -6,7 +6,7 @@ import stripComments from 'strip-json-comments'
 import { Kommand } from '../../common'
 
 export class ConfigDiff extends Kommand {
-  static description = 'Returns differences between two Kuzzle configuration files (kuzzlerc)'
+  static description = 'Returns differences between the keys of two Kuzzle configuration files (kuzzlerc)'
 
   static examples = [
     'kourou config:diff config/local/kuzzlerc config/production/kuzzlerc'

--- a/src/commands/config/key-diff.ts
+++ b/src/commands/config/key-diff.ts
@@ -5,11 +5,11 @@ import stripComments from 'strip-json-comments'
 
 import { Kommand } from '../../common'
 
-export class ConfigDiff extends Kommand {
+export class ConfigKeyDiff extends Kommand {
   static description = 'Returns differences between the keys of two Kuzzle configuration files (kuzzlerc)'
 
   static examples = [
-    'kourou config:diff config/local/kuzzlerc config/production/kuzzlerc'
+    'kourou config:key-diff config/local/kuzzlerc config/production/kuzzlerc'
   ]
 
   static flags = {
@@ -25,9 +25,7 @@ export class ConfigDiff extends Kommand {
   ]
 
   async runSafe() {
-    this.printCommand()
-
-    const { args, flags: userFlags } = this.parse(ConfigDiff)
+    const { args, flags: userFlags } = this.parse(ConfigKeyDiff)
 
     if (!fs.existsSync(args.first)) {
       throw new Error(`File "${args.first}" does not exists`)

--- a/src/commands/document/create.ts
+++ b/src/commands/document/create.ts
@@ -31,9 +31,7 @@ export default class DocumentCreate extends Kommand {
   ]
 
   async runSafe() {
-    this.printCommand()
-
-    const { args, flags: userFlags } = this.parse(DocumentCreate)
+        const { args, flags: userFlags } = this.parse(DocumentCreate)
 
     this.sdk = new KuzzleSDK(userFlags)
     await this.sdk.init(this.log)

--- a/src/commands/document/get.ts
+++ b/src/commands/document/get.ts
@@ -17,8 +17,6 @@ export default class DocumentGet extends Kommand {
   ]
 
   async runSafe() {
-    this.printCommand()
-
     const { args, flags: userFlags } = this.parse(DocumentGet)
 
     this.sdk = new KuzzleSDK(userFlags)

--- a/src/commands/document/search.ts
+++ b/src/commands/document/search.ts
@@ -42,9 +42,7 @@ export default class DocumentSearch extends Kommand {
   ]
 
   async runSafe() {
-    this.printCommand()
-
-    const { args, flags: userFlags } = this.parse(DocumentSearch)
+        const { args, flags: userFlags } = this.parse(DocumentSearch)
 
     const sdk = new KuzzleSDK(userFlags)
     await sdk.init(this.log)

--- a/src/commands/es/get.ts
+++ b/src/commands/es/get.ts
@@ -25,8 +25,6 @@ export default class EsGet extends Kommand {
   ]
 
   async runSafe() {
-    this.printCommand()
-
     const { args, flags: userFlags } = this.parse(EsGet)
 
     const node = `http://${userFlags.host}:${userFlags.port}`

--- a/src/commands/es/insert.ts
+++ b/src/commands/es/insert.ts
@@ -31,8 +31,6 @@ export default class EsInsert extends Kommand {
   ]
 
   async runSafe() {
-    this.printCommand()
-
     const { args, flags: userFlags } = this.parse(EsInsert)
 
     const node = `http://${userFlags.host}:${userFlags.port}`

--- a/src/commands/es/list-index.ts
+++ b/src/commands/es/list-index.ts
@@ -24,8 +24,6 @@ export default class EsListIndex extends Kommand {
   }
 
   async runSafe() {
-    this.printCommand()
-
     const { flags: userFlags } = this.parse(EsListIndex)
 
     const node = `http://${userFlags.host}:${userFlags.port}`

--- a/src/commands/file/decrypt.ts
+++ b/src/commands/file/decrypt.ts
@@ -33,8 +33,6 @@ export class FileDecrypt extends Kommand {
   ]
 
   async runSafe() {
-    this.printCommand()
-
     const { args, flags: userFlags } = this.parse(FileDecrypt)
 
     if (_.isEmpty(userFlags['vault-key'])) {

--- a/src/commands/file/encrypt.ts
+++ b/src/commands/file/encrypt.ts
@@ -33,8 +33,6 @@ export class VaultEncrypt extends Kommand {
   ]
 
   async runSafe() {
-    this.printCommand()
-
     const { args, flags: userFlags } = this.parse(VaultEncrypt)
 
     if (_.isEmpty(userFlags['vault-key'])) {

--- a/src/commands/file/test.ts
+++ b/src/commands/file/test.ts
@@ -24,8 +24,6 @@ export class FileTest extends Kommand {
   ]
 
   async runSafe() {
-    this.printCommand()
-
     const { args, flags: userFlags } = this.parse(FileTest)
 
     if (_.isEmpty(userFlags['vault-key'])) {

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -38,8 +38,6 @@ export default class Import extends Kommand {
   ]
 
   async runSafe() {
-    this.printCommand()
-
     const { args, flags: userFlags } = this.parse(Import)
 
     this.userFlags = userFlags

--- a/src/commands/index/export.ts
+++ b/src/commands/index/export.ts
@@ -26,8 +26,6 @@ export default class IndexExport extends Kommand {
   ]
 
   async runSafe() {
-    this.printCommand()
-
     const { args, flags: userFlags } = this.parse(IndexExport)
 
     const path = userFlags.path ? `${userFlags.path}/${args.index}` : args.index

--- a/src/commands/index/import.ts
+++ b/src/commands/index/import.ts
@@ -1,6 +1,5 @@
 import * as path from 'path'
 import * as fs from 'fs'
-import chalk from 'chalk'
 
 import { flags } from '@oclif/command'
 import { Kommand } from '../../common'
@@ -8,7 +7,12 @@ import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
 import { restoreCollectionData, restoreCollectionMappings } from '../../support/restore-collection'
 
 export default class IndexImport extends Kommand {
-  static description = 'Imports an index'
+  static description = ''
+
+  static examples = [
+    'kourou index:import ./dump/iot-data',
+    'kourou index:import ./dump/iot-data --index iot-data-production --no-mappings'
+  ]
 
   static flags = {
     help: flags.help({}),
@@ -40,10 +44,10 @@ export default class IndexImport extends Kommand {
     await this.sdk.init(this.log)
 
     if (index) {
-      this.log(chalk.green(`[✔] Start importing dump from ${args.path} in index ${index}`))
+      this.logOk(`Start importing dump from ${args.path} in index ${index}`)
     }
     else {
-      this.log(chalk.green(`[✔] Start importing dump from ${args.path} in same index`))
+      this.logOk(`Start importing dump from ${args.path} in same index`)
     }
 
     const dumpDirs = fs.readdirSync(args.path).map(f => `${args.path}/${f}`)
@@ -60,24 +64,24 @@ export default class IndexImport extends Kommand {
             index)
         }
 
-        const { total, collection } = await restoreCollectionData(
+        const { total, collection, index: dstIndex } = await restoreCollectionData(
           this.sdk,
           this.log.bind(this),
           Number(userFlags['batch-size']),
           path.join(dumpDir, 'documents.jsonl'),
           index)
 
-        this.logOk(`Successfully imported ${total} documents in "${index}:${collection}"`)
+        this.logOk(`Successfully imported ${total} documents in "${dstIndex}:${collection}"`)
       }
       catch (error) {
         this.logError(`Error when importing collection from "${dumpDir}": ${error}`)
       }
 
       if (index) {
-        this.log(chalk.green(`[✔] Dump directory ${dumpDir} imported in index ${index}`))
+        this.logOk(`Dump directory ${dumpDir} imported in index ${index}`)
       }
       else {
-        this.log(chalk.green(`[✔] Dump directory ${dumpDir} imported`))
+        this.logOk(`Dump directory ${dumpDir} imported`)
       }
     }
   }

--- a/src/commands/index/import.ts
+++ b/src/commands/index/import.ts
@@ -34,8 +34,6 @@ export default class IndexImport extends Kommand {
   ]
 
   async runSafe() {
-    this.printCommand()
-
     const { args, flags: userFlags } = this.parse(IndexImport)
 
     const index = userFlags.index

--- a/src/commands/index/import.ts
+++ b/src/commands/index/import.ts
@@ -48,7 +48,7 @@ export default class IndexImport extends Kommand {
       this.logOk(`Start importing dump from ${args.path} in same index`)
     }
 
-    const dumpDirs = fs.readdirSync(args.path).map(f => `${args.path}/${f}`)
+    const dumpDirs = fs.readdirSync(args.path).map(f => path.join(args.path, f))
 
     for (const dumpDir of dumpDirs) {
       try {
@@ -73,13 +73,6 @@ export default class IndexImport extends Kommand {
       }
       catch (error) {
         this.logError(`Error when importing collection from "${dumpDir}": ${error}`)
-      }
-
-      if (index) {
-        this.logOk(`Dump directory ${dumpDir} imported in index ${index}`)
-      }
-      else {
-        this.logOk(`Dump directory ${dumpDir} imported`)
       }
     }
   }

--- a/src/commands/instance/logs.ts
+++ b/src/commands/instance/logs.ts
@@ -18,8 +18,6 @@ export class InstanceLogs extends Kommand {
   }
 
   async runSafe() {
-    this.printCommand()
-
     const { flags } = this.parse(InstanceLogs)
     let instance: string = flags.instance!
     const followOption: boolean = flags.follow

--- a/src/commands/instance/spawn.ts
+++ b/src/commands/instance/spawn.ts
@@ -100,8 +100,6 @@ export default class InstanceSpawn extends Kommand {
   };
 
   async runSafe() {
-    this.printCommand()
-
     const { flags: userFlags } = this.parse(InstanceSpawn)
     const portIndex = await this.findAvailablePort()
     const docoFilename = `/tmp/kuzzle-stack-${portIndex}.yml`

--- a/src/commands/profile/export.ts
+++ b/src/commands/profile/export.ts
@@ -21,8 +21,6 @@ export default class ProfileExport extends Kommand {
   }
 
   async runSafe() {
-    this.printCommand()
-
     const { flags: userFlags } = this.parse(ProfileExport)
 
     this.path = userFlags.path

--- a/src/commands/profile/import.ts
+++ b/src/commands/profile/import.ts
@@ -20,8 +20,6 @@ export default class ProfileImport extends Kommand {
   ]
 
   async runSafe() {
-    this.printCommand()
-
     const { args, flags: userFlags } = this.parse(ProfileImport)
 
     this.path = args.path

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -35,9 +35,7 @@ class Query extends Kommand {
   ]
 
   async runSafe() {
-    this.printCommand()
-
-    const { args, flags: userFlags } = this.parse(Query)
+        const { args, flags: userFlags } = this.parse(Query)
 
     this.sdk = new KuzzleSDK(userFlags)
     await this.sdk.init(this.log)

--- a/src/commands/role/export.ts
+++ b/src/commands/role/export.ts
@@ -21,8 +21,6 @@ export default class RoleDump extends Kommand {
   }
 
   async runSafe() {
-    this.printCommand()
-
     const { flags: userFlags } = this.parse(RoleDump)
 
     this.path = userFlags.path

--- a/src/commands/role/import.ts
+++ b/src/commands/role/import.ts
@@ -20,8 +20,6 @@ export default class RoleImport extends Kommand {
   ]
 
   async runSafe() {
-    this.printCommand()
-
     const { args, flags: userFlags } = this.parse(RoleImport)
 
     this.path = args.path

--- a/src/commands/vault/add.ts
+++ b/src/commands/vault/add.ts
@@ -34,8 +34,6 @@ See https://github.com/kuzzleio/kuzzle-vault/ for more information.
   ]
 
   async runSafe() {
-    this.printCommand()
-
     const { args, flags: userFlags } = this.parse(VaultAdd)
 
     if (_.isEmpty(userFlags['vault-key'])) {

--- a/src/commands/vault/decrypt.ts
+++ b/src/commands/vault/decrypt.ts
@@ -39,8 +39,6 @@ See https://github.com/kuzzleio/kuzzle-vault/ for more information.
   ]
 
   async runSafe() {
-    this.printCommand()
-
     const { args, flags: userFlags } = this.parse(VaultDecrypt)
 
     if (_.isEmpty(userFlags['vault-key'])) {

--- a/src/commands/vault/encrypt.ts
+++ b/src/commands/vault/encrypt.ts
@@ -50,8 +50,6 @@ See https://github.com/kuzzleio/kuzzle-vault/ for more information.
   ]
 
   async runSafe() {
-    this.printCommand()
-
     const { args, flags: userFlags } = this.parse(VaultEncrypt)
 
     if (_.isEmpty(userFlags['vault-key'])) {

--- a/src/commands/vault/show.ts
+++ b/src/commands/vault/show.ts
@@ -35,8 +35,6 @@ See https://github.com/kuzzleio/kuzzle-vault/ for more information.
   ]
 
   async runSafe() {
-    this.printCommand()
-
     const { args, flags: userFlags } = this.parse(VaultShow)
 
     if (_.isEmpty(userFlags['vault-key'])) {

--- a/src/commands/vault/test.ts
+++ b/src/commands/vault/test.ts
@@ -27,8 +27,6 @@ See https://github.com/kuzzleio/kuzzle-vault/ for more information.
   ]
 
   async runSafe() {
-    this.printCommand()
-
     const { args, flags: userFlags } = this.parse(VaultTest)
 
     if (_.isEmpty(userFlags['vault-key'])) {

--- a/src/common.ts
+++ b/src/common.ts
@@ -45,6 +45,7 @@ export abstract class Kommand extends Command {
 
   async run() {
     try {
+      this.printCommand()
       await this.runSafe()
     }
     catch (error) {


### PR DESCRIPTION
## What does this PR do?

Adds a command to spot differences between kuzzlerc files to ensure configuration consistency between environments.

```
kourou-dev config:diff config/local/kuzzlerc config/production/kuzzlerc
 
 🚀 Kourou - Returns differences between two Kuzzle configuration files (kuzzlerc)
 
 [ℹ] Found key differences between the provided configurations. In the second file:
  - key "plugins.omniscient.s3BucketsRegion" was added
  - key "plugins.sentry.dsn" was added
  - key "plugins.sentry.excludeIntegrations" was added
  - key "plugins.sentry.dsn" is "production" and was "local" 
```

![kouro-config-diff](https://user-images.githubusercontent.com/4447392/80183792-c370d200-8609-11ea-8a24-a56fbc78100c.gif)