### PR TITLE
Refactor

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ By environment variables:
 * [`kourou collection:create INDEX COLLECTION`](#kourou-collectioncreate-index-collection)
 * [`kourou collection:export INDEX COLLECTION`](#kourou-collectionexport-index-collection)
 * [`kourou collection:import PATH`](#kourou-collectionimport-path)
-* [`kourou config:key-diff FIRST SECOND`](#kourou-configkey-diff-first-second)
+* [`kourou config:diff FIRST SECOND`](#kourou-configdiff-first-second)
 * [`kourou document:create INDEX COLLECTION`](#kourou-documentcreate-index-collection)
 * [`kourou document:get INDEX COLLECTION ID`](#kourou-documentget-index-collection-id)
 * [`kourou document:search INDEX COLLECTION`](#kourou-documentsearch-index-collection)
@@ -103,10 +103,11 @@ ARGUMENTS
   TOKEN  API key token
 
 OPTIONS
-  -h, --host=host      [default: localhost] Kuzzle server host
-  -p, --port=port      [default: 7512] Kuzzle server port
   --help               show CLI help
+  --host=host          [default: localhost] Kuzzle server host
   --password=password  Kuzzle user password
+  --port=port          [default: 7512] Kuzzle server port
+  --protocol=protocol  [default: http] Kuzzle protocol (http or websocket)
   --ssl                Use SSL to connect to Kuzzle
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 
@@ -129,12 +130,13 @@ ARGUMENTS
 
 OPTIONS
   -d, --description=description  (required) API Key description
-  -h, --host=host                [default: localhost] Kuzzle server host
-  -p, --port=port                [default: 7512] Kuzzle server port
   --expire=expire                [default: -1] API Key validity
   --help                         show CLI help
+  --host=host                    [default: localhost] Kuzzle server host
   --id=id                        API Key unique ID
   --password=password            Kuzzle user password
+  --port=port                    [default: 7512] Kuzzle server port
+  --protocol=protocol            [default: http] Kuzzle protocol (http or websocket)
   --ssl                          Use SSL to connect to Kuzzle
   --username=username            [default: anonymous] Kuzzle username (local strategy)
 ```
@@ -154,10 +156,11 @@ ARGUMENTS
   ID    API Key unique ID
 
 OPTIONS
-  -h, --host=host      [default: localhost] Kuzzle server host
-  -p, --port=port      [default: 7512] Kuzzle server port
   --help               show CLI help
+  --host=host          [default: localhost] Kuzzle server host
   --password=password  Kuzzle user password
+  --port=port          [default: 7512] Kuzzle server port
+  --protocol=protocol  [default: http] Kuzzle protocol (http or websocket)
   --ssl                Use SSL to connect to Kuzzle
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 
@@ -179,11 +182,12 @@ ARGUMENTS
   USER  User kuid
 
 OPTIONS
-  -h, --host=host      [default: localhost] Kuzzle server host
-  -p, --port=port      [default: 7512] Kuzzle server port
   --filter=filter      Filter to match the API Key descriptions
   --help               show CLI help
+  --host=host          [default: localhost] Kuzzle server host
   --password=password  Kuzzle user password
+  --port=port          [default: 7512] Kuzzle server port
+  --protocol=protocol  [default: http] Kuzzle protocol (http or websocket)
   --ssl                Use SSL to connect to Kuzzle
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 ```
@@ -203,15 +207,18 @@ ARGUMENTS
   COLLECTION  Collection name
 
 OPTIONS
-  -h, --host=host      [default: localhost] Kuzzle server host
-  -p, --port=port      [default: 7512] Kuzzle server port
-
   --body=body          [default: {}] Collection mappings and settings in JS or JSON format. Will be read from STDIN if
                        available
 
   --help               show CLI help
 
+  --host=host          [default: localhost] Kuzzle server host
+
   --password=password  Kuzzle user password
+
+  --port=port          [default: 7512] Kuzzle server port
+
+  --protocol=protocol  [default: http] Kuzzle protocol (http or websocket)
 
   --ssl                Use SSL to connect to Kuzzle
 
@@ -233,13 +240,14 @@ ARGUMENTS
   COLLECTION  Collection name
 
 OPTIONS
-  -h, --host=host          [default: localhost] Kuzzle server host
-  -p, --port=port          [default: 7512] Kuzzle server port
   --batch-size=batch-size  [default: 2000] Maximum batch size (see limits.documentsFetchCount config)
   --editor                 Open an editor (EDITOR env variable) to edit the query before sending
   --help                   show CLI help
+  --host=host              [default: localhost] Kuzzle server host
   --password=password      Kuzzle user password
   --path=path              Dump root directory
+  --port=port              [default: 7512] Kuzzle server port
+  --protocol=protocol      [default: websocket] Kuzzle protocol (http or websocket)
   --query=query            [default: {}] Only dump documents matching the query (JS or JSON format)
   --ssl                    Use SSL to connect to Kuzzle
   --username=username      [default: anonymous] Kuzzle username (local strategy)
@@ -263,40 +271,41 @@ ARGUMENTS
   PATH  Dump directory path
 
 OPTIONS
-  -h, --host=host          [default: localhost] Kuzzle server host
-  -p, --port=port          [default: 7512] Kuzzle server port
   --batch-size=batch-size  [default: 200] Maximum batch size (see limits.documentsWriteCount config)
   --collection=collection  If set, override the collection destination name
   --help                   show CLI help
+  --host=host              [default: localhost] Kuzzle server host
   --index=index            If set, override the index destination name
   --no-mappings            Skip collection mappings
   --password=password      Kuzzle user password
+  --port=port              [default: 7512] Kuzzle server port
+  --protocol=protocol      [default: websocket] Kuzzle protocol (http or websocket)
   --ssl                    Use SSL to connect to Kuzzle
   --username=username      [default: anonymous] Kuzzle username (local strategy)
 ```
 
 _See code: [src/commands/collection/import.ts](https://github.com/kuzzleio/kourou/blob/v0.11.0/src/commands/collection/import.ts)_
 
-## `kourou config:key-diff FIRST SECOND`
+## `kourou config:diff FIRST SECOND`
 
-Returns differences between the keys of two Kuzzle configuration files (kuzzlerc)
+Returns differences between two Kuzzle configuration files (kuzzlerc)
 
 ```
 USAGE
-  $ kourou config:key-diff FIRST SECOND
+  $ kourou config:diff FIRST SECOND
 
 ARGUMENTS
   FIRST   First configuration file
   SECOND  Second configuration file
 
 OPTIONS
-  --strict  Exit with an error if diff are found
+  --strict  Exit with an error if differences are found
 
 EXAMPLE
-  kourou config:key-diff config/local/kuzzlerc config/production/kuzzlerc
+  kourou config:diff config/local/kuzzlerc config/production/kuzzlerc
 ```
 
-_See code: [src/commands/config/key-diff.ts](https://github.com/kuzzleio/kourou/blob/v0.11.0/src/commands/config/key-diff.ts)_
+_See code: [src/commands/config/diff.ts](https://github.com/kuzzleio/kourou/blob/v0.11.0/src/commands/config/diff.ts)_
 
 ## `kourou document:create INDEX COLLECTION`
 
@@ -311,12 +320,13 @@ ARGUMENTS
   COLLECTION  Collection name
 
 OPTIONS
-  -h, --host=host      [default: localhost] Kuzzle server host
-  -p, --port=port      [default: 7512] Kuzzle server port
   --body=body          [default: {}] Document body in JS or JSON format. Will be read from STDIN if available
   --help               show CLI help
+  --host=host          [default: localhost] Kuzzle server host
   --id=id              Optional document ID
   --password=password  Kuzzle user password
+  --port=port          [default: 7512] Kuzzle server port
+  --protocol=protocol  [default: http] Kuzzle protocol (http or websocket)
   --replace            Replaces the document if it already exists
   --ssl                Use SSL to connect to Kuzzle
   --username=username  [default: anonymous] Kuzzle username (local strategy)
@@ -342,10 +352,11 @@ ARGUMENTS
   ID          Document ID
 
 OPTIONS
-  -h, --host=host      [default: localhost] Kuzzle server host
-  -p, --port=port      [default: 7512] Kuzzle server port
   --help               show CLI help
+  --host=host          [default: localhost] Kuzzle server host
   --password=password  Kuzzle user password
+  --port=port          [default: 7512] Kuzzle server port
+  --protocol=protocol  [default: http] Kuzzle protocol (http or websocket)
   --ssl                Use SSL to connect to Kuzzle
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 ```
@@ -365,12 +376,13 @@ ARGUMENTS
   COLLECTION  Collection name
 
 OPTIONS
-  -h, --host=host      [default: localhost] Kuzzle server host
-  -p, --port=port      [default: 7512] Kuzzle server port
   --editor             Open an editor (EDITOR env variable) to edit the request before sending
   --from=from          Optional offset
   --help               show CLI help
+  --host=host          [default: localhost] Kuzzle server host
   --password=password  Kuzzle user password
+  --port=port          [default: 7512] Kuzzle server port
+  --protocol=protocol  [default: http] Kuzzle protocol (http or websocket)
   --query=query        [default: {}] Query in JS or JSON format.
   --scroll=scroll      Optional scroll TTL
   --size=size          Optional page size
@@ -538,11 +550,12 @@ ARGUMENTS
   PATH  Root directory containing dumps
 
 OPTIONS
-  -h, --host=host          [default: localhost] Kuzzle server host
-  -p, --port=port          [default: 7512] Kuzzle server port
   --batch-size=batch-size  [default: 200] Maximum batch size (see limits.documentsWriteCount config)
   --help                   show CLI help
+  --host=host              [default: localhost] Kuzzle server host
   --password=password      Kuzzle user password
+  --port=port              [default: 7512] Kuzzle server port
+  --protocol=protocol      [default: websocket] Kuzzle protocol (http or websocket)
   --ssl                    Use SSL to connect to Kuzzle
   --username=username      [default: anonymous] Kuzzle username (local strategy)
 ```
@@ -561,12 +574,13 @@ ARGUMENTS
   INDEX  Index name
 
 OPTIONS
-  -h, --host=host          [default: localhost] Kuzzle server host
-  -p, --port=port          [default: 7512] Kuzzle server port
   --batch-size=batch-size  [default: 2000] Maximum batch size (see limits.documentsFetchCount config)
   --help                   show CLI help
+  --host=host              [default: localhost] Kuzzle server host
   --password=password      Kuzzle user password
   --path=path              Dump root directory
+  --port=port              [default: 7512] Kuzzle server port
+  --protocol=protocol      [default: websocket] Kuzzle protocol (http or websocket)
   --ssl                    Use SSL to connect to Kuzzle
   --username=username      [default: anonymous] Kuzzle username (local strategy)
 ```
@@ -574,6 +588,8 @@ OPTIONS
 _See code: [src/commands/index/export.ts](https://github.com/kuzzleio/kourou/blob/v0.11.0/src/commands/index/export.ts)_
 
 ## `kourou index:import PATH`
+
+Imports an index (JSONL format)
 
 ```
 USAGE
@@ -583,13 +599,14 @@ ARGUMENTS
   PATH  Dump directory or file
 
 OPTIONS
-  -h, --host=host          [default: localhost] Kuzzle server host
-  -p, --port=port          [default: 7512] Kuzzle server port
   --batch-size=batch-size  [default: 200] Maximum batch size (see limits.documentsWriteCount config)
   --help                   show CLI help
+  --host=host              [default: localhost] Kuzzle server host
   --index=index            If set, override the index destination name
   --no-mappings            Skip collections mappings
   --password=password      Kuzzle user password
+  --port=port              [default: 7512] Kuzzle server port
+  --protocol=protocol      [default: websocket] Kuzzle protocol (http or websocket)
   --ssl                    Use SSL to connect to Kuzzle
   --username=username      [default: anonymous] Kuzzle username (local strategy)
 
@@ -640,11 +657,12 @@ USAGE
   $ kourou profile:export
 
 OPTIONS
-  -h, --host=host      [default: localhost] Kuzzle server host
-  -p, --port=port      [default: 7512] Kuzzle server port
   --help               show CLI help
+  --host=host          [default: localhost] Kuzzle server host
   --password=password  Kuzzle user password
   --path=path          [default: profiles] Dump directory
+  --port=port          [default: 7512] Kuzzle server port
+  --protocol=protocol  [default: websocket] Kuzzle protocol (http or websocket)
   --ssl                Use SSL to connect to Kuzzle
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 ```
@@ -663,10 +681,11 @@ ARGUMENTS
   PATH  Dump file
 
 OPTIONS
-  -h, --host=host      [default: localhost] Kuzzle server host
-  -p, --port=port      [default: 7512] Kuzzle server port
   --help               show CLI help
+  --host=host          [default: localhost] Kuzzle server host
   --password=password  Kuzzle user password
+  --port=port          [default: 7512] Kuzzle server port
+  --protocol=protocol  [default: websocket] Kuzzle protocol (http or websocket)
   --ssl                Use SSL to connect to Kuzzle
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 ```
@@ -675,7 +694,7 @@ _See code: [src/commands/profile/import.ts](https://github.com/kuzzleio/kourou/b
 
 ## `kourou query CONTROLLER:ACTION`
 
-Executes an API query
+Executes an API query.
 
 ```
 USAGE
@@ -685,21 +704,46 @@ ARGUMENTS
   CONTROLLER:ACTION  Controller and action (eg: "server:now")
 
 OPTIONS
-  -a, --arg=arg        Additional argument. Repeatable. (e.g. "-a refresh=wait_for")
-  -h, --host=host      [default: localhost] Kuzzle server host
-  -p, --port=port      [default: 7512] Kuzzle server port
-  --body=body          [default: {}] Request body in JS or JSON format. Will be read from STDIN if available.
-  --editor             Open an editor (EDITOR env variable) to edit the request before sending
-  --help               show CLI help
-  --password=password  Kuzzle user password
-  --ssl                Use SSL to connect to Kuzzle
-  --username=username  [default: anonymous] Kuzzle username (local strategy)
+  -a, --arg=arg                Additional argument. Repeatable. (e.g. "-a refresh=wait_for")
+  -c, --collection=collection  Collection argument
+  -i, --index=index            Index argument
+  --body=body                  [default: {}] Request body in JS or JSON format. Will be read from STDIN if available.
+  --editor                     Open an editor (EDITOR env variable) to edit the request before sending.
+  --help                       show CLI help
+  --host=host                  [default: localhost] Kuzzle server host
+  --password=password          Kuzzle user password
+  --port=port                  [default: 7512] Kuzzle server port
+  --protocol=protocol          [default: http] Kuzzle protocol (http or websocket)
+  --ssl                        Use SSL to connect to Kuzzle
+  --username=username          [default: anonymous] Kuzzle username (local strategy)
 
-EXAMPLES
-  kourou query document:get --arg index=iot --arg collection=sensors --arg _id=sigfox-42
-  kourou query collection:create --arg index=iot --arg collection=sensors --body '{dynamic: "strict"}'
-  kourou query admin:loadMappings < mappings.json
-  echo '{name: "Aschen"}' | kourou query document:create --arg index=iot --arg collection=sensors
+DESCRIPTION
+  Executes an API query.
+
+  Query arguments
+
+     arguments can be passed and repeated using the --arg or -a flag.
+     index and collection names can be passed with --index (-i) and --collection (-c) flags
+
+     Examples:
+       - kourou query document:get -i iot -c sensors -a _id=sigfox-42
+
+  Query body
+
+     body can be passed with the --body flag with either a JSON or JS string.
+     body will be read from STDIN if available
+
+     Examples:
+       - kourou query document:create -i iot -c sensors --body '{creation: Date.now())}'
+       - kourou query admin:loadMappings < mappings.json
+       - echo '{dynamic: "strict"}' | kourou query collection:create -i iot -c sensors
+
+  Other
+
+     use the --editor flag to modify the query before sending it to Kuzzle
+
+     Examples:
+       - kourou query document:create -i iot -c sensors --editor
 ```
 
 _See code: [src/commands/query.ts](https://github.com/kuzzleio/kourou/blob/v0.11.0/src/commands/query.ts)_
@@ -713,11 +757,12 @@ USAGE
   $ kourou role:export
 
 OPTIONS
-  -h, --host=host      [default: localhost] Kuzzle server host
-  -p, --port=port      [default: 7512] Kuzzle server port
   --help               show CLI help
+  --host=host          [default: localhost] Kuzzle server host
   --password=password  Kuzzle user password
   --path=path          [default: roles] Dump directory
+  --port=port          [default: 7512] Kuzzle server port
+  --protocol=protocol  [default: websocket] Kuzzle protocol (http or websocket)
   --ssl                Use SSL to connect to Kuzzle
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 ```
@@ -736,10 +781,11 @@ ARGUMENTS
   PATH  Dump file
 
 OPTIONS
-  -h, --host=host      [default: localhost] Kuzzle server host
-  -p, --port=port      [default: 7512] Kuzzle server port
   --help               show CLI help
+  --host=host          [default: localhost] Kuzzle server host
   --password=password  Kuzzle user password
+  --port=port          [default: 7512] Kuzzle server port
+  --protocol=protocol  [default: websocket] Kuzzle protocol (http or websocket)
   --ssl                Use SSL to connect to Kuzzle
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 ```

--- a/features/Query.feature
+++ b/features/Query.feature
@@ -11,3 +11,10 @@ Feature: Query
       | flag | --body                   | { "other-name": "my" } |
     Then The document "chuon-chuon-kim" content match:
       | other-name | "my" |
+
+  Scenario: Impersonate an user
+    When I run the command "query" with:
+      | arg  | auth:getCurrentUser |        |
+      | flag | --as                | gordon |
+    Then I should match stdout with "\"_id\": \"jean\""
+

--- a/features/Query.feature
+++ b/features/Query.feature
@@ -11,10 +11,3 @@ Feature: Query
       | flag | --body                   | { "other-name": "my" } |
     Then The document "chuon-chuon-kim" content match:
       | other-name | "my" |
-
-  Scenario: Impersonate an user
-    When I run the command "query" with:
-      | arg  | auth:getCurrentUser |        |
-      | flag | --as                | gordon |
-    Then I should match stdout with "\"_id\": \"jean\""
-

--- a/src/commands/api-key/check.ts
+++ b/src/commands/api-key/check.ts
@@ -1,6 +1,7 @@
 import { flags } from '@oclif/command'
+
 import { Kommand } from '../../common'
-import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
+import { kuzzleFlags } from '../../support/kuzzle'
 
 class ApiKeyCheck extends Kommand {
   public static description = 'Checks an API key validity';
@@ -19,12 +20,7 @@ class ApiKeyCheck extends Kommand {
   ]
 
   async runSafe() {
-    const { args, flags: userFlags } = this.parse(ApiKeyCheck)
-
-    this.sdk = new KuzzleSDK(userFlags)
-    await this.sdk.init(this.log)
-
-    const { valid } = await this.sdk.auth.checkToken(args.token)
+    const { valid } = await this.sdk?.auth.checkToken(this.args.token)
 
     if (valid) {
       this.logOk('API key is still valid')

--- a/src/commands/api-key/create.ts
+++ b/src/commands/api-key/create.ts
@@ -1,6 +1,7 @@
 import { flags } from '@oclif/command'
+
 import { Kommand } from '../../common'
-import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
+import { kuzzleFlags } from '../../support/kuzzle'
 
 class ApiKeyCreate extends Kommand {
   public static description = 'Creates a new API Key for a user';
@@ -27,20 +28,15 @@ class ApiKeyCreate extends Kommand {
   ]
 
   async runSafe() {
-    const { args, flags: userFlags } = this.parse(ApiKeyCreate)
-
-    this.sdk = new KuzzleSDK(userFlags)
-    await this.sdk.init(this.log)
-
-    const apiKey = await this.sdk.security.createApiKey(
-      args.user,
-      userFlags.description,
+    const apiKey = await this.sdk?.security.createApiKey(
+      this.args.user,
+      this.flags.description,
       {
-        _id: userFlags.id,
-        expiresIn: userFlags.expire
+        _id: this.flags.id,
+        expiresIn: this.flags.expire
       })
 
-    this.log(`Successfully created API Key "${apiKey._id}" for user "${args.user}"`)
+    this.logOk(`Successfully created API Key "${apiKey._id}" for user "${this.args.user}"`)
     this.log(apiKey._source.token)
   }
 }

--- a/src/commands/api-key/delete.ts
+++ b/src/commands/api-key/delete.ts
@@ -1,6 +1,7 @@
 import { flags } from '@oclif/command'
+
 import { Kommand } from '../../common'
-import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
+import { kuzzleFlags } from '../../support/kuzzle'
 
 class ApiKeyDelete extends Kommand {
   public static description = 'Deletes an API key.';
@@ -20,14 +21,9 @@ class ApiKeyDelete extends Kommand {
   ];
 
   async runSafe() {
-    const { flags: userFlags, args } = this.parse(ApiKeyDelete)
+    await this.sdk?.security.deleteApiKey(this.args.user, this.args.id)
 
-    this.sdk = new KuzzleSDK(userFlags)
-    await this.sdk.init(this.log)
-
-    await this.sdk.security.deleteApiKey(args.user, args.id)
-
-    this.log(`Successfully deleted API Key "${args.id}" of user "${args.user}"`)
+    this.logOk(`Successfully deleted API Key "${this.args.id}" of user "${this.args.user}"`)
   }
 }
 

--- a/src/commands/api-key/search.ts
+++ b/src/commands/api-key/search.ts
@@ -1,6 +1,7 @@
 import { flags } from '@oclif/command'
+
 import { Kommand } from '../../common'
-import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
+import { kuzzleFlags } from '../../support/kuzzle'
 
 class ApiKeySearch extends Kommand {
   public static description = 'Lists a user\'s API Keys.';
@@ -18,29 +19,24 @@ class ApiKeySearch extends Kommand {
   ]
 
   async runSafe() {
-    const { flags: userFlags, args } = this.parse(ApiKeySearch)
-
-    this.sdk = new KuzzleSDK(userFlags)
-    await this.sdk.init(this.log)
-
     let query = {}
-    if (userFlags.filter) {
+    if (this.flags.filter) {
       query = {
         match: {
-          description: userFlags.filter,
+          description: this.flags.filter,
         },
       }
     }
 
-    const result = await this.sdk.security.searchApiKeys(
-      args.user,
+    const result = await this.sdk?.security.searchApiKeys(
+      this.args.user,
       query,
       {
         from: 0,
         size: 100
       })
 
-    this.log(`${result.total} API Keys found for user ${args.user}`)
+    this.logOk(`${result.total} API Keys found for user ${this.args.user}`)
 
     if (result.total !== 0) {
       this.log('')

--- a/src/commands/collection/create.ts
+++ b/src/commands/collection/create.ts
@@ -1,6 +1,7 @@
 import { flags } from '@oclif/command'
+
 import { Kommand } from '../../common'
-import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
+import { kuzzleFlags } from '../../support/kuzzle'
 
 export default class CollectionCreate extends Kommand {
   static description = 'Creates a collection'
@@ -20,25 +21,18 @@ export default class CollectionCreate extends Kommand {
   ]
 
   async runSafe() {
-    const { args, flags: userFlags } = this.parse(CollectionCreate)
-
-    this.sdk = new KuzzleSDK(userFlags)
-    await this.sdk.init(this.log)
-
     const stdin = await this.fromStdin()
 
-    const body = stdin
-      ? this.parseJs(stdin)
-      : this.parseJs(userFlags.body)
+    const body = stdin ? this.parseJs(stdin) : this.parseJs(this.flags.body)
 
-    if (!await this.sdk.index.exists(args.index)) {
-      await this.sdk.index.create(args.index)
+    if (!await this.sdk?.index.exists(this.args.index)) {
+      await this.sdk?.index.create(this.args.index)
 
-      this.logOk(`Index "${args.index}" created`)
+      this.logInfo(`Index "${this.args.index}" created`)
     }
 
-    await this.sdk.collection.create(args.index, args.collection, body)
+    await this.sdk?.collection.create(this.args.index, this.args.collection, body)
 
-    this.logOk(`Collection "${args.index}":"${args.collection}" created`)
+    this.logOk(`Collection "${this.args.index}":"${this.args.collection}" created`)
   }
 }

--- a/src/commands/collection/export.ts
+++ b/src/commands/collection/export.ts
@@ -1,9 +1,10 @@
 import { flags } from '@oclif/command'
-import { Kommand } from '../../common'
-import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
-import { dumpCollectionData, dumpCollectionMappings } from '../../support/dump-collection'
 import * as fs from 'fs'
-import chalk from 'chalk'
+import path from 'path'
+
+import { Kommand } from '../../common'
+import { kuzzleFlags } from '../../support/kuzzle'
+import { dumpCollectionData, dumpCollectionMappings } from '../../support/dump-collection'
 
 export default class CollectionExport extends Kommand {
   static description = 'Exports a collection (JSONL format)'
@@ -25,6 +26,10 @@ export default class CollectionExport extends Kommand {
       description: 'Open an editor (EDITOR env variable) to edit the query before sending'
     }),
     ...kuzzleFlags,
+    protocol: flags.string({
+      description: 'Kuzzle protocol (http or websocket)',
+      default: 'websocket',
+    }),
   }
 
   static args = [
@@ -38,40 +43,37 @@ export default class CollectionExport extends Kommand {
   ]
 
   async runSafe() {
-    const { args, flags: userFlags } = this.parse(CollectionExport)
+    const exportPath = this.flags.path
+      ? path.join(this.flags.path, this.args.index)
+      : this.args.index
 
-    const path = userFlags.path ? `${userFlags.path}/${args.index}` : args.index
+    let query = this.parseJs(this.flags.query)
 
-    this.sdk = new KuzzleSDK({ protocol: 'ws', ...userFlags })
-    await this.sdk.init(this.log)
-
-    let query = this.parseJs(userFlags.query)
-
-    if (userFlags.editor) {
+    if (this.flags.editor) {
       query = this.fromEditor(query, { json: true })
     }
 
-    const countAll = await this.sdk.document.count(args.index, args.collection)
-    const count = await this.sdk.document.count(args.index, args.collection, { query })
+    const countAll = await this.sdk?.document.count(this.args.index, this.args.collection)
+    const count = await this.sdk?.document.count(this.args.index, this.args.collection, { query })
 
-    this.log(`Dumping ${count} of ${countAll} documents from collection "${args.index}:${args.collection}" in ${path}/ ...`)
+    this.logInfo(`Dumping ${count} of ${countAll} documents from collection "${this.args.index}:${this.args.collection}" in ${path}/ ...`)
 
-    fs.mkdirSync(path, { recursive: true })
+    fs.mkdirSync(exportPath, { recursive: true })
 
     await dumpCollectionMappings(
       this.sdk,
-      args.index,
-      args.collection,
-      path)
+      this.args.index,
+      this.args.collection,
+      exportPath)
 
     await dumpCollectionData(
       this.sdk,
-      args.index,
-      args.collection,
-      Number(userFlags['batch-size']),
-      path,
+      this.args.index,
+      this.args.collection,
+      Number(this.flags['batch-size']),
+      exportPath,
       query)
 
-    this.log(chalk.green(`[✔] Collection ${args.index}:${args.collection} dumped`))
+    this.logOk(`Collection ${this.args.index}:${this.args.collection} dumped`)
   }
 }

--- a/src/commands/collection/import.ts
+++ b/src/commands/collection/import.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs'
 
 import { flags } from '@oclif/command'
 import { Kommand } from '../../common'
-import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
+import { kuzzleFlags } from '../../support/kuzzle'
 import { restoreCollectionData, restoreCollectionMappings } from '../../support/restore-collection'
 
 export default class CollectionImport extends Kommand {
@@ -25,6 +25,10 @@ export default class CollectionImport extends Kommand {
       description: 'Skip collection mappings'
     }),
     ...kuzzleFlags,
+    protocol: flags.string({
+      description: 'Kuzzle protocol (http or websocket)',
+      default: 'websocket',
+    }),
   }
 
   static args = [
@@ -32,38 +36,27 @@ export default class CollectionImport extends Kommand {
   ]
 
   async runSafe() {
-    const { args, flags: userFlags } = this.parse(CollectionImport)
+    this.logInfo(`Start importing dump from ${this.args.path}`)
 
-    const index = userFlags.index
-    const collection = userFlags.collection
-
-    this.sdk = new KuzzleSDK({ protocol: 'ws', loginTTL: '1d', ...userFlags })
-
-    await this.sdk.init(this.log)
-
-    this.logInfo(`Start importing dump from ${args.path}`)
-
-    if (!userFlags['no-mappings']) {
-      const mappingsPath = path.join(args.path, 'mappings.json')
+    if (!this.flags['no-mappings']) {
+      const mappingsPath = path.join(this.args.path, 'mappings.json')
       const dump = JSON.parse(fs.readFileSync(mappingsPath, 'utf8'))
 
       await restoreCollectionMappings(
         this.sdk,
         dump,
-        index,
-        collection)
+        this.flags.index,
+        this.flags.collection)
     }
 
     const { total } = await restoreCollectionData(
       this.sdk,
       this.log.bind(this),
-      Number(userFlags['batch-size']),
-      path.join(args.path, 'documents.jsonl'),
-      index,
-      collection)
+      Number(this.flags['batch-size']),
+      path.join(this.args.path, 'documents.jsonl'),
+      this.flags.index,
+      this.flags.collection)
 
-    this.logOk(`Successfully imported ${total} documents in "${index}:${collection}"`)
-
-    this.logOk(`Dump directory ${args.path} imported`)
+    this.logOk(`Successfully imported ${total} documents from "${this.args.path}" in "${this.flags.index}:${this.flags.collection}"`)
   }
 }

--- a/src/commands/config/diff.ts
+++ b/src/commands/config/diff.ts
@@ -6,6 +6,8 @@ import stripComments from 'strip-json-comments'
 import { Kommand } from '../../common'
 
 export class ConfigKeyDiff extends Kommand {
+  static initSdk = false
+
   static description = 'Returns differences between two Kuzzle configuration files (kuzzlerc)'
 
   static examples = [

--- a/src/commands/config/diff.ts
+++ b/src/commands/config/diff.ts
@@ -6,10 +6,10 @@ import stripComments from 'strip-json-comments'
 import { Kommand } from '../../common'
 
 export class ConfigKeyDiff extends Kommand {
-  static description = 'Returns differences between the keys of two Kuzzle configuration files (kuzzlerc)'
+  static description = 'Returns differences between two Kuzzle configuration files (kuzzlerc)'
 
   static examples = [
-    'kourou config:key-diff config/local/kuzzlerc config/production/kuzzlerc'
+    'kourou config:diff config/local/kuzzlerc config/production/kuzzlerc'
   ]
 
   static flags = {
@@ -25,18 +25,16 @@ export class ConfigKeyDiff extends Kommand {
   ]
 
   async runSafe() {
-    const { args, flags: userFlags } = this.parse(ConfigKeyDiff)
-
-    if (!fs.existsSync(args.first)) {
-      throw new Error(`File "${args.first}" does not exists`)
+    if (!fs.existsSync(this.args.first)) {
+      throw new Error(`File "${this.args.first}" does not exists`)
     }
 
-    if (!fs.existsSync(args.second)) {
-      throw new Error(`File "${args.second}" does not exists`)
+    if (!fs.existsSync(this.args.second)) {
+      throw new Error(`File "${this.args.second}" does not exists`)
     }
 
-    const first = JSON.parse(stripComments(fs.readFileSync(args.first, 'utf8')))
-    const second = JSON.parse(stripComments(fs.readFileSync(args.second, 'utf8')))
+    const first = JSON.parse(stripComments(fs.readFileSync(this.args.first, 'utf8')))
+    const second = JSON.parse(stripComments(fs.readFileSync(this.args.second, 'utf8')))
 
     const changes = this._keyChanges(first, second)
 
@@ -51,7 +49,7 @@ export class ConfigKeyDiff extends Kommand {
       this.log(` - key "${path}" ${change}`)
     }
 
-    if (userFlags.strict) {
+    if (this.flags.strict) {
       throw new Error('Provided configuration contains different keys')
     }
   }

--- a/src/commands/document/create.ts
+++ b/src/commands/document/create.ts
@@ -1,6 +1,7 @@
 import { flags } from '@oclif/command'
+
 import { Kommand } from '../../common'
-import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
+import { kuzzleFlags } from '../../support/kuzzle'
 
 export default class DocumentCreate extends Kommand {
   static description = 'Creates a document'
@@ -31,36 +32,29 @@ export default class DocumentCreate extends Kommand {
   ]
 
   async runSafe() {
-        const { args, flags: userFlags } = this.parse(DocumentCreate)
-
-    this.sdk = new KuzzleSDK(userFlags)
-    await this.sdk.init(this.log)
-
     const stdin = await this.fromStdin()
 
-    const body = stdin
-      ? stdin
-      : userFlags.body
+    const body = stdin ? stdin : this.flags.body
 
-    let document: any
-
-    if (userFlags.replace) {
-      document = await this.sdk.document.replace(
-        args.index,
-        args.collection,
-        userFlags.id,
+    if (this.flags.replace) {
+      const document = await this.sdk?.document.replace(
+        this.args.index,
+        this.args.collection,
+        this.flags.id,
         this.parseJs(body),
         { refresh: 'wait_for' })
+
+      this.logOk(`Document "${document._id}" successfully replaced`)
     }
     else {
-      document = await this.sdk.document.create(
-        args.index,
-        args.collection,
+      const document = await this.sdk?.document.create(
+        this.args.index,
+        this.args.collection,
         this.parseJs(body),
-        userFlags.id,
+        this.flags.id,
         { refresh: 'wait_for' })
-    }
 
-    this.log(JSON.stringify(document, null, 2))
+      this.logOk(`Document "${document._id}" successfully created`)
+    }
   }
 }

--- a/src/commands/document/get.ts
+++ b/src/commands/document/get.ts
@@ -1,6 +1,7 @@
 import { flags } from '@oclif/command'
+
 import { Kommand } from '../../common'
-import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
+import { kuzzleFlags } from '../../support/kuzzle'
 
 export default class DocumentGet extends Kommand {
   static description = 'Gets a document'
@@ -17,15 +18,10 @@ export default class DocumentGet extends Kommand {
   ]
 
   async runSafe() {
-    const { args, flags: userFlags } = this.parse(DocumentGet)
-
-    this.sdk = new KuzzleSDK(userFlags)
-    await this.sdk.init(this.log)
-
-    const document = await this.sdk.document.get(
-      args.index,
-      args.collection,
-      args.id)
+    const document = await this.sdk?.document.get(
+      this.args.index,
+      this.args.collection,
+      this.args.id)
 
     this.log(JSON.stringify(document, null, 2))
   }

--- a/src/commands/document/search.ts
+++ b/src/commands/document/search.ts
@@ -1,7 +1,7 @@
 import { flags } from '@oclif/command'
+
 import { Kommand } from '../../common'
-import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
-import chalk from 'chalk'
+import { kuzzleFlags } from '../../support/kuzzle'
 
 export default class DocumentSearch extends Kommand {
   static description = 'Searches for documents'
@@ -42,37 +42,32 @@ export default class DocumentSearch extends Kommand {
   ]
 
   async runSafe() {
-        const { args, flags: userFlags } = this.parse(DocumentSearch)
-
-    const sdk = new KuzzleSDK(userFlags)
-    await sdk.init(this.log)
-
     let request: any = {
       controller: 'document',
       action: 'search',
-      index: args.index,
-      collection: args.collection,
-      from: userFlags.from,
-      size: userFlags.size,
-      scroll: userFlags.scroll,
+      index: this.args.index,
+      collection: this.args.collection,
+      from: this.flags.from,
+      size: this.flags.size,
+      scroll: this.flags.scroll,
       body: {
-        query: this.parseJs(userFlags.query),
-        sort: this.parseJs(userFlags.sort)
+        query: this.parseJs(this.flags.query),
+        sort: this.parseJs(this.flags.sort)
       }
     }
 
     // allow to edit request before send
-    if (userFlags.editor) {
+    if (this.flags.editor) {
       request = this.fromEditor(request, { json: true })
     }
 
-    const { result } = await sdk.query(request)
+    const { result } = await this.sdk?.query(request)
 
     for (const document of result.hits) {
-      this.log(chalk.yellow(`Document ID: ${document._id}`))
+      this.logInfo(`Document ID: ${document._id}`)
       this.log(`Content: ${JSON.stringify(document._source, null, 2)}`)
     }
 
-    this.log(chalk.green(`${result.hits.length} documents fetched on a total of ${result.total}`))
+    this.logOk(`${result.hits.length} documents fetched on a total of ${result.total}`)
   }
 }

--- a/src/commands/es/get.ts
+++ b/src/commands/es/get.ts
@@ -28,6 +28,7 @@ export default class EsGet extends Kommand {
   ]
 
   async runSafe() {
+    // @todo support ssl
     const node = `http://${this.flags.host}:${this.flags.port}`
 
     const esClient = new Client({ node })

--- a/src/commands/es/get.ts
+++ b/src/commands/es/get.ts
@@ -1,8 +1,11 @@
 import { flags } from '@oclif/command'
-import { Kommand } from '../../common'
 import { Client } from '@elastic/elasticsearch'
 
+import { Kommand } from '../../common'
+
 export default class EsGet extends Kommand {
+  static initSdk = false
+
   static description = 'Gets a document from ES'
 
   static flags = {
@@ -25,23 +28,17 @@ export default class EsGet extends Kommand {
   ]
 
   async runSafe() {
-    const { args, flags: userFlags } = this.parse(EsGet)
+    const node = `http://${this.flags.host}:${this.flags.port}`
 
-    const node = `http://${userFlags.host}:${userFlags.port}`
     const esClient = new Client({ node })
+
     const esRequest = {
-      index: args.index,
-      id: args.id
+      index: this.args.index,
+      id: this.args.id
     }
 
-    try {
-      const { body } = await esClient.get(esRequest)
+    const { body } = await esClient.get(esRequest)
 
-      this.log(JSON.stringify(body, null, 2))
-    }
-    catch (error) {
-      this.logError(JSON.stringify(error, null, 2))
-      throw error
-    }
+    this.log(JSON.stringify(body, null, 2))
   }
 }

--- a/src/commands/es/insert.ts
+++ b/src/commands/es/insert.ts
@@ -1,8 +1,11 @@
 import { flags } from '@oclif/command'
-import { Kommand } from '../../common'
 import { Client } from '@elastic/elasticsearch'
 
+import { Kommand } from '../../common'
+
 export default class EsInsert extends Kommand {
+  static initSdk = false
+
   static description = 'Inserts a document directly into ES (will replace if exists)'
 
   static flags = {
@@ -31,24 +34,18 @@ export default class EsInsert extends Kommand {
   ]
 
   async runSafe() {
-    const { args, flags: userFlags } = this.parse(EsInsert)
+    const node = `http://${this.flags.host}:${this.flags.port}`
 
-    const node = `http://${userFlags.host}:${userFlags.port}`
     const esClient = new Client({ node })
+
     const esRequest = {
-      index: args.index,
-      id: userFlags.id,
-      body: userFlags.body,
+      index: this.args.index,
+      id: this.flags.id,
+      body: this.flags.body,
     }
 
-    try {
-      const { body } = await esClient.index(esRequest)
+    await esClient.index(esRequest)
 
-      this.log(JSON.stringify(body, null, 2))
-    }
-    catch (error) {
-      this.logError(JSON.stringify(error, null, 2))
-      throw error
-    }
+    this.logOk('Document successfully inserted.')
   }
 }

--- a/src/commands/es/insert.ts
+++ b/src/commands/es/insert.ts
@@ -34,6 +34,7 @@ export default class EsInsert extends Kommand {
   ]
 
   async runSafe() {
+    // @todo support ssl
     const node = `http://${this.flags.host}:${this.flags.port}`
 
     const esClient = new Client({ node })

--- a/src/commands/es/list-index.ts
+++ b/src/commands/es/list-index.ts
@@ -27,6 +27,7 @@ export default class EsListIndex extends Kommand {
   }
 
   async runSafe() {
+    // @todo support ssl
     const node = `http://${this.flags.host}:${this.flags.port}`
 
     const esClient = new Client({ node })

--- a/src/commands/file/decrypt.ts
+++ b/src/commands/file/decrypt.ts
@@ -6,6 +6,8 @@ import { Cryptonomicon } from 'kuzzle-vault'
 import { Kommand } from '../../common'
 
 export class FileDecrypt extends Kommand {
+  static initSdk = false
+
   static description = 'Decrypts an encrypted file.'
 
   static examples = [
@@ -33,37 +35,35 @@ export class FileDecrypt extends Kommand {
   ]
 
   async runSafe() {
-    const { args, flags: userFlags } = this.parse(FileDecrypt)
-
-    if (_.isEmpty(userFlags['vault-key'])) {
+    if (_.isEmpty(this.flags['vault-key'])) {
       throw new Error('A vault key must be provided')
     }
 
-    if (_.isEmpty(args.file)) {
+    if (_.isEmpty(this.args.file)) {
       throw new Error('An encrypted file must be provided')
     }
 
-    let outputFile = `${args.file.replace('.enc', '')}`
-    if (userFlags['output-file']) {
-      outputFile = userFlags['output-file']
+    let outputFile = `${this.args.file.replace('.enc', '')}`
+    if (this.flags['output-file']) {
+      outputFile = this.flags['output-file']
     }
 
-    if (fs.existsSync(outputFile) && !userFlags.force) {
+    if (fs.existsSync(outputFile) && !this.flags.force) {
       throw new Error(`Output file "${outputFile}" already exists. Use -f flag to overwrite it.`)
     }
 
-    const cryptonomicon = new Cryptonomicon(userFlags['vault-key'])
+    const cryptonomicon = new Cryptonomicon(this.flags['vault-key'])
 
-    if (!fs.existsSync(args.file)) {
-      throw new Error(`File "${args.file}" does not exists`)
+    if (!fs.existsSync(this.args.file)) {
+      throw new Error(`File "${this.args.file}" does not exists`)
     }
 
     let encryptedContent
     try {
-      encryptedContent = fs.readFileSync(args.file, 'utf8')
+      encryptedContent = fs.readFileSync(this.args.file, 'utf8')
     }
     catch (error) {
-      throw new Error(`Cannot read encrypted content from file "${args.file}": ${error.message}`)
+      throw new Error(`Cannot read encrypted content from file "${this.args.file}": ${error.message}`)
     }
 
     const content = cryptonomicon.decryptString(encryptedContent)

--- a/src/commands/file/encrypt.ts
+++ b/src/commands/file/encrypt.ts
@@ -6,6 +6,8 @@ import { Cryptonomicon } from 'kuzzle-vault'
 import { Kommand } from '../../common'
 
 export class VaultEncrypt extends Kommand {
+  static initSdk = false
+
   static description = 'Encrypts an entire file.'
 
   static examples = [
@@ -33,37 +35,35 @@ export class VaultEncrypt extends Kommand {
   ]
 
   async runSafe() {
-    const { args, flags: userFlags } = this.parse(VaultEncrypt)
-
-    if (_.isEmpty(userFlags['vault-key'])) {
+    if (_.isEmpty(this.flags['vault-key'])) {
       throw new Error('A vault key must be provided')
     }
 
-    if (_.isEmpty(args.file)) {
+    if (_.isEmpty(this.args.file)) {
       throw new Error('A file must be provided')
     }
 
-    let outputFile = `${args.file}.enc`
-    if (userFlags['output-file']) {
-      outputFile = userFlags['output-file']
+    let outputFile = `${this.args.file}.enc`
+    if (this.flags['output-file']) {
+      outputFile = this.flags['output-file']
     }
 
-    if (fs.existsSync(outputFile) && !userFlags.force) {
+    if (fs.existsSync(outputFile) && !this.flags.force) {
       throw new Error(`Output file "${outputFile}" already exists. Use -f flag to overwrite it.`)
     }
 
-    const cryptonomicon = new Cryptonomicon(userFlags['vault-key'])
+    const cryptonomicon = new Cryptonomicon(this.flags['vault-key'])
 
-    if (!fs.existsSync(args.file)) {
-      throw new Error(`File "${args.file}" does not exists`)
+    if (!fs.existsSync(this.args.file)) {
+      throw new Error(`File "${this.args.file}" does not exists`)
     }
 
     let content
     try {
-      content = fs.readFileSync(args.file, 'utf8')
+      content = fs.readFileSync(this.args.file, 'utf8')
     }
     catch (error) {
-      throw new Error(`Cannot read file "${args.file}": ${error.message}`)
+      throw new Error(`Cannot read file "${this.args.file}": ${error.message}`)
     }
 
     const encryptedContent = cryptonomicon.encryptString(content)

--- a/src/commands/file/test.ts
+++ b/src/commands/file/test.ts
@@ -6,6 +6,8 @@ import { Cryptonomicon } from 'kuzzle-vault'
 import { Kommand } from '../../common'
 
 export class FileTest extends Kommand {
+  static initSdk = false
+
   static description = 'Tests if an encrypted file can be decrypted.'
 
   static examples = [
@@ -24,28 +26,26 @@ export class FileTest extends Kommand {
   ]
 
   async runSafe() {
-    const { args, flags: userFlags } = this.parse(FileTest)
-
-    if (_.isEmpty(userFlags['vault-key'])) {
+    if (_.isEmpty(this.flags['vault-key'])) {
       throw new Error('A vault key must be provided')
     }
 
-    if (_.isEmpty(args.file)) {
+    if (_.isEmpty(this.args.file)) {
       throw new Error('An encrypted file must be provided')
     }
 
-    if (!fs.existsSync(args.file)) {
-      throw new Error(`Encrypted file "${args.file} does not exists`)
+    if (!fs.existsSync(this.args.file)) {
+      throw new Error(`Encrypted file "${this.args.file} does not exists`)
     }
 
-    const cryptonomicon = new Cryptonomicon(userFlags['vault-key'])
+    const cryptonomicon = new Cryptonomicon(this.flags['vault-key'])
 
     let encryptedContent
     try {
-      encryptedContent = fs.readFileSync(args.file, 'utf8')
+      encryptedContent = fs.readFileSync(this.args.file, 'utf8')
     }
     catch (error) {
-      throw new Error(`Cannot read encrypted content from file "${args.file}": ${error.message}`)
+      throw new Error(`Cannot read encrypted content from file "${this.args.file}": ${error.message}`)
     }
 
     try {

--- a/src/commands/index/export.ts
+++ b/src/commands/index/export.ts
@@ -1,10 +1,11 @@
 import { flags } from '@oclif/command'
-import { Kommand } from '../../common'
-import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
-import { dumpCollectionData, dumpCollectionMappings } from '../../support/dump-collection'
 import * as fs from 'fs'
 import cli from 'cli-ux'
-import chalk from 'chalk'
+import path from 'path'
+
+import { Kommand } from '../../common'
+import { kuzzleFlags } from '../../support/kuzzle'
+import { dumpCollectionData, dumpCollectionMappings } from '../../support/dump-collection'
 
 export default class IndexExport extends Kommand {
   static description = 'Exports an index (JSONL format)'
@@ -19,6 +20,10 @@ export default class IndexExport extends Kommand {
       default: '2000'
     }),
     ...kuzzleFlags,
+    protocol: flags.string({
+      description: 'Kuzzle protocol (http or websocket)',
+      default: 'websocket',
+    }),
   }
 
   static args = [
@@ -26,34 +31,31 @@ export default class IndexExport extends Kommand {
   ]
 
   async runSafe() {
-    const { args, flags: userFlags } = this.parse(IndexExport)
+    const exportPath = this.flags.path
+      ? path.join(this.flags.path, this.args.index)
+      : this.args.index
 
-    const path = userFlags.path ? `${userFlags.path}/${args.index}` : args.index
+    this.logInfo(`Dumping index "${this.args.index}" in ${exportPath}/ ...`)
 
-    this.sdk = new KuzzleSDK({ protocol: 'ws', ...userFlags })
-    await this.sdk.init(this.log)
+    fs.mkdirSync(exportPath, { recursive: true })
 
-    this.log(chalk.green(`Dumping index "${args.index}" in ${path}/ ...`))
-
-    fs.mkdirSync(path, { recursive: true })
-
-    const { collections } = await this.sdk.collection.list(args.index)
+    const { collections } = await this.sdk?.collection.list(this.args.index)
 
     for (const collection of collections) {
       try {
         if (collection.type !== 'realtime') {
           await dumpCollectionMappings(
             this.sdk,
-            args.index,
+            this.args.index,
             collection.name,
-            path)
+            exportPath)
 
           await dumpCollectionData(
             this.sdk,
-            args.index,
+            this.args.index,
             collection.name,
-            Number(userFlags['batch-size']),
-            path)
+            Number(this.flags['batch-size']),
+            exportPath)
 
           cli.action.stop()
         }
@@ -63,6 +65,6 @@ export default class IndexExport extends Kommand {
       }
     }
 
-    this.log(chalk.green(`[✔] Index ${args.index} dumped`))
+    this.logOk(`Index ${this.args.index} dumped`)
   }
 }

--- a/src/commands/index/export.ts
+++ b/src/commands/index/export.ts
@@ -61,7 +61,7 @@ export default class IndexExport extends Kommand {
         }
       }
       catch (error) {
-        this.logError(`Error when exporting collection "${collection.name}": ${error}`)
+        this.logKo(`Error when exporting collection "${collection.name}": ${error}`)
       }
     }
 

--- a/src/commands/index/import.ts
+++ b/src/commands/index/import.ts
@@ -69,7 +69,7 @@ export default class IndexImport extends Kommand {
         this.logOk(`Successfully imported ${total} documents in "${dstIndex}:${collection}"`)
       }
       catch (error) {
-        this.logError(`Error when importing collection from "${dumpDir}": ${error}`)
+        this.logKo(`Error when importing collection from "${dumpDir}": ${error}`)
       }
     }
   }

--- a/src/commands/index/import.ts
+++ b/src/commands/index/import.ts
@@ -3,7 +3,7 @@ import * as fs from 'fs'
 
 import { flags } from '@oclif/command'
 import { Kommand } from '../../common'
-import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
+import { kuzzleFlags } from '../../support/kuzzle'
 import { restoreCollectionData, restoreCollectionMappings } from '../../support/restore-collection'
 
 export default class IndexImport extends Kommand {
@@ -38,8 +38,6 @@ export default class IndexImport extends Kommand {
   ]
 
   async runSafe() {
-    this.sdk = new KuzzleSDK({ protocol: 'ws', ...this.flags })
-
     if (this.flags.index) {
       this.logInfo(`Start importing dump from ${this.args.path} in index ${this.flags.index}`)
     }

--- a/src/commands/instance/logs.ts
+++ b/src/commands/instance/logs.ts
@@ -1,7 +1,8 @@
-import { Kommand } from '../../common'
 import { flags } from '@oclif/command'
 import * as inquirer from 'inquirer'
 import execa from 'execa'
+
+import { Kommand } from '../../common'
 
 export class InstanceLogs extends Kommand {
   static description = 'Displays the logs of a running Kuzzle'
@@ -18,9 +19,8 @@ export class InstanceLogs extends Kommand {
   }
 
   async runSafe() {
-    const { flags } = this.parse(InstanceLogs)
-    let instance: string = flags.instance!
-    const followOption: boolean = flags.follow
+    let instance: string = this.flags.instance!
+    const followOption: boolean = this.flags.follow
 
     if (!instance) {
       const instancesList = await this.getInstancesList()

--- a/src/commands/instance/logs.ts
+++ b/src/commands/instance/logs.ts
@@ -5,6 +5,8 @@ import execa from 'execa'
 import { Kommand } from '../../common'
 
 export class InstanceLogs extends Kommand {
+  static initSdk = false
+
   static description = 'Displays the logs of a running Kuzzle'
 
   static flags = {

--- a/src/commands/instance/spawn.ts
+++ b/src/commands/instance/spawn.ts
@@ -234,7 +234,7 @@ export default class InstanceSpawn extends Kommand {
       await checks.run()
       return true
     } catch (error) {
-      this.logError(error.message)
+      this.logKo(error.message)
       return false
     }
   }

--- a/src/commands/instance/spawn.ts
+++ b/src/commands/instance/spawn.ts
@@ -7,6 +7,7 @@ import { writeFileSync } from 'fs'
 import Listr from 'listr'
 import net from 'net'
 import emoji from 'node-emoji'
+
 import { Kommand } from '../../common'
 
 const MIN_MAX_MAP_COUNT = 262144
@@ -100,18 +101,17 @@ export default class InstanceSpawn extends Kommand {
   };
 
   async runSafe() {
-    const { flags: userFlags } = this.parse(InstanceSpawn)
     const portIndex = await this.findAvailablePort()
     const docoFilename = `/tmp/kuzzle-stack-${portIndex}.yml`
 
-    const successfullCheck = userFlags.check ?
+    const successfullCheck = this.flags.check ?
       await this.checkPrerequisites() :
       true
 
-    if (userFlags.check && successfullCheck) {
+    if (this.flags.check && successfullCheck) {
       this.log(
         `\n${emoji.get('ok_hand')} Prerequisites are ${chalk.green.bold('OK')}!`)
-    } else if (userFlags.check && !successfullCheck) {
+    } else if (this.flags.check && !successfullCheck) {
       throw new Error(
         `${emoji.get('shrug')} Your system doesn't satisfy all the prerequisites. Cannot run Kuzzle.`)
     }
@@ -119,7 +119,7 @@ export default class InstanceSpawn extends Kommand {
     this.log(
       chalk.grey(`\nWriting docker-compose file to ${docoFilename}...`),
     )
-    writeFileSync(docoFilename, this.generateDocoFile(userFlags.version, portIndex))
+    writeFileSync(docoFilename, this.generateDocoFile(this.flags.version, portIndex))
 
     // clean up
     await execa('docker-compose', ['-f', docoFilename, '-p', `stack-${portIndex}`, 'down'])
@@ -129,7 +129,7 @@ export default class InstanceSpawn extends Kommand {
       ['-f', docoFilename, '-p', `stack-${portIndex}`, 'up', '-d'])
 
     cli.action.start(
-      ` ${emoji.get('rocket')} Kuzzle version ${userFlags.version} is launching`,
+      ` ${emoji.get('rocket')} Kuzzle version ${this.flags.version} is launching`,
       undefined,
       {
         stdout: true,

--- a/src/commands/instance/spawn.ts
+++ b/src/commands/instance/spawn.ts
@@ -85,6 +85,8 @@ services:
       nofile: 65536
 `
 export default class InstanceSpawn extends Kommand {
+  static initSdk = false
+
   public static description = 'Spawn a new Kuzzle instance';
 
   public static flags = {

--- a/src/commands/profile/import.ts
+++ b/src/commands/profile/import.ts
@@ -1,18 +1,20 @@
 import { flags } from '@oclif/command'
-import { Kommand } from '../../common'
-import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
 import * as fs from 'fs'
-import chalk from 'chalk'
+
+import { Kommand } from '../../common'
+import { kuzzleFlags } from '../../support/kuzzle'
 import { restoreProfiles } from '../../support/restore-securities'
 
 export default class ProfileImport extends Kommand {
-  private path?: string;
-
   static description = 'Imports profiles'
 
   static flags = {
     help: flags.help({}),
     ...kuzzleFlags,
+    protocol: flags.string({
+      description: 'Kuzzle protocol (http or websocket)',
+      default: 'websocket',
+    }),
   }
 
   static args = [
@@ -20,21 +22,12 @@ export default class ProfileImport extends Kommand {
   ]
 
   async runSafe() {
-    const { args, flags: userFlags } = this.parse(ProfileImport)
+    this.logInfo(`Importing profiles from ${this.args.path} ...`)
 
-    this.path = args.path
-
-    this.sdk = new KuzzleSDK(userFlags)
-    await this.sdk.init(this.log)
-
-    const filename: any = this.path
-
-    this.log(`Restoring profiles from ${filename} ...`)
-
-    const dump = JSON.parse(fs.readFileSync(filename, 'utf-8'))
+    const dump = JSON.parse(fs.readFileSync(this.args.path, 'utf-8'))
 
     const count = await restoreProfiles(this.sdk, dump)
 
-    this.log(chalk.green(`[✔] ${count} profiles restored`))
+    this.logOk(`${count} profiles restored`)
   }
 }

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -31,7 +31,6 @@ Other
 
   Examples:
     - kourou query document:create -i iot -c sensors --editor
-    - kourou query auth:getCurrentUser --as sigfox-gateway
 `;
 
   public static flags = {

--- a/src/commands/query.ts
+++ b/src/commands/query.ts
@@ -1,17 +1,38 @@
 import { flags } from '@oclif/command'
+
 import { Kommand } from '../common'
-import { kuzzleFlags, KuzzleSDK } from '../support/kuzzle'
-import chalk from 'chalk'
+import { kuzzleFlags } from '../support/kuzzle'
 
 class Query extends Kommand {
-  public static description = 'Executes an API query';
+  public static description = `
+Executes an API query.
 
-  public static examples = [
-    'kourou query document:get --arg index=iot --arg collection=sensors --arg _id=sigfox-42',
-    'kourou query collection:create --arg index=iot --arg collection=sensors --body \'{dynamic: "strict"}\'',
-    'kourou query admin:loadMappings < mappings.json',
-    'echo \'{name: "Aschen"}\' | kourou query document:create --arg index=iot --arg collection=sensors'
-  ]
+Query arguments
+
+  arguments can be passed and repeated using the --arg or -a flag.
+  index and collection names can be passed with --index (-i) and --collection (-c) flags
+
+  Examples:
+    - kourou query document:get -i iot -c sensors -a _id=sigfox-42
+
+Query body
+
+  body can be passed with the --body flag with either a JSON or JS string.
+  body will be read from STDIN if available
+
+  Examples:
+    - kourou query document:create -i iot -c sensors --body '{creation: Date.now())}'
+    - kourou query admin:loadMappings < mappings.json
+    - echo '{dynamic: "strict"}' | kourou query collection:create -i iot -c sensors
+
+Other
+
+  use the --editor flag to modify the query before sending it to Kuzzle
+
+  Examples:
+    - kourou query document:create -i iot -c sensors --editor
+    - kourou query auth:getCurrentUser --as sigfox-gateway
+`;
 
   public static flags = {
     help: flags.help(),
@@ -25,7 +46,15 @@ class Query extends Kommand {
       default: '{}'
     }),
     editor: flags.boolean({
-      description: 'Open an editor (EDITOR env variable) to edit the request before sending'
+      description: 'Open an editor (EDITOR env variable) to edit the request before sending.'
+    }),
+    index: flags.string({
+      char: 'i',
+      description: 'Index argument'
+    }),
+    collection: flags.string({
+      char: 'c',
+      description: 'Collection argument'
     }),
     ...kuzzleFlags,
   };
@@ -35,16 +64,14 @@ class Query extends Kommand {
   ]
 
   async runSafe() {
-        const { args, flags: userFlags } = this.parse(Query)
-
-    this.sdk = new KuzzleSDK(userFlags)
-    await this.sdk.init(this.log)
-
-    const [controller, action] = args['controller:action'].split(':')
+    const [controller, action] = this.args['controller:action'].split(':')
 
     const requestArgs: any = {}
 
-    for (const keyValue of userFlags.arg || []) {
+    requestArgs.index = this.flags.index
+    requestArgs.collection = this.flags.collection
+
+    for (const keyValue of this.flags.arg || []) {
       const [key, ...value] = keyValue.split('=')
       requestArgs[key] = value.join()
     }
@@ -52,12 +79,12 @@ class Query extends Kommand {
     // try to read stdin
     const stdin = await this.fromStdin()
 
-    if (stdin && userFlags.editor) {
+    if (stdin && this.flags.editor) {
       throw new Error('Unable to use flag --editor when reading from STDIN')
     }
     const body = stdin
       ? stdin
-      : userFlags.body
+      : this.flags.body
 
     let request = {
       controller,
@@ -67,14 +94,15 @@ class Query extends Kommand {
     }
 
     // content from user editor
-    if (userFlags.editor) {
+    if (this.flags.editor) {
       request = this.fromEditor(request, { json: true })
     }
 
-    const response = await this.sdk.query(request)
+    const response = await this.sdk?.query(request)
 
-    this.log(chalk.green(`Successfully executed "${controller}:${action}"`))
     this.log(JSON.stringify(response, null, 2))
+
+    this.logOk(`Successfully executed "${controller}:${action}"`)
   }
 }
 

--- a/src/commands/role/export.ts
+++ b/src/commands/role/export.ts
@@ -1,14 +1,11 @@
+import * as fs from 'fs'
+import path from 'path'
+
 import { flags } from '@oclif/command'
 import { Kommand } from '../../common'
-import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
-import * as fs from 'fs'
-import chalk from 'chalk'
+import { kuzzleFlags } from '../../support/kuzzle'
 
 export default class RoleDump extends Kommand {
-  private batchSize?: string;
-
-  private path?: string;
-
   static description = 'Exports roles'
 
   static flags = {
@@ -18,21 +15,18 @@ export default class RoleDump extends Kommand {
       default: 'roles'
     }),
     ...kuzzleFlags,
+    protocol: flags.string({
+      description: 'Kuzzle protocol (http or websocket)',
+      default: 'websocket',
+    }),
   }
 
   async runSafe() {
-    const { flags: userFlags } = this.parse(RoleDump)
+    const filename = path.join(this.flags.path, 'roles.json')
 
-    this.path = userFlags.path
+    this.logInfo(`Exporting roles in ${filename} ...`)
 
-    const filename = `${this.path}/roles.json`
-
-    this.sdk = new KuzzleSDK(userFlags)
-    await this.sdk.init(this.log)
-
-    this.log(`Dumping roles in ${filename} ...`)
-
-    fs.mkdirSync(this.path, { recursive: true })
+    fs.mkdirSync(this.flags.path, { recursive: true })
 
     const roles = await this._dumpRoles()
 
@@ -43,20 +37,16 @@ export default class RoleDump extends Kommand {
 
     fs.writeFileSync(filename, JSON.stringify(dump, null, 2))
 
-    this.log(chalk.green(`[✔] ${Object.keys(roles).length} roles dumped`))
+    this.logOk(`${Object.keys(roles).length} roles dumped`)
   }
 
   async _dumpRoles() {
     const options = {
-      scroll: '10s',
+      scroll: '3s',
       size: 100
     }
 
-    let result
-    // f*** you TS
-    if (this.sdk) {
-      result = await this.sdk.security.searchRoles({}, options)
-    }
+    let result = await this.sdk?.security.searchRoles({}, options)
 
     const roles: any = {}
 

--- a/src/commands/role/import.ts
+++ b/src/commands/role/import.ts
@@ -2,9 +2,8 @@ import * as fs from 'fs'
 
 import { flags } from '@oclif/command'
 import { Kommand } from '../../common'
-import { kuzzleFlags } from '../support/kuzzle'
+import { kuzzleFlags } from '../../support/kuzzle'
 import { restoreRoles } from '../../support/restore-securities'
-
 export default class RoleImport extends Kommand {
   static description = 'Import roles'
 

--- a/src/commands/role/import.ts
+++ b/src/commands/role/import.ts
@@ -1,18 +1,20 @@
+import * as fs from 'fs'
+
 import { flags } from '@oclif/command'
 import { Kommand } from '../../common'
-import { kuzzleFlags, KuzzleSDK } from '../../support/kuzzle'
-import * as fs from 'fs'
-import chalk from 'chalk'
+import { kuzzleFlags } from '../support/kuzzle'
 import { restoreRoles } from '../../support/restore-securities'
 
 export default class RoleImport extends Kommand {
-  private path?: string;
-
   static description = 'Import roles'
 
   static flags = {
     help: flags.help({}),
     ...kuzzleFlags,
+    protocol: flags.string({
+      description: 'Kuzzle protocol (http or websocket)',
+      default: 'websocket',
+    }),
   }
 
   static args = [
@@ -20,21 +22,12 @@ export default class RoleImport extends Kommand {
   ]
 
   async runSafe() {
-    const { args, flags: userFlags } = this.parse(RoleImport)
+    this.logInfo(`Importing roles from ${this.args.path} ...`)
 
-    this.path = args.path
-
-    this.sdk = new KuzzleSDK(userFlags)
-    await this.sdk.init(this.log)
-
-    const filename: any = this.path
-
-    this.log(`Restoring roles from ${filename} ...`)
-
-    const dump = JSON.parse(fs.readFileSync(filename, 'utf-8'))
+    const dump = JSON.parse(fs.readFileSync(this.args.path, 'utf-8'))
 
     const count = await restoreRoles(this.sdk, dump)
 
-    this.log(chalk.green(`[✔] ${count} roles restored`))
+    this.logOk(`${count} roles restored`)
   }
 }

--- a/src/commands/vault/add.ts
+++ b/src/commands/vault/add.ts
@@ -6,6 +6,8 @@ import { Cryptonomicon } from 'kuzzle-vault'
 import { Kommand } from '../../common'
 
 export class VaultAdd extends Kommand {
+  static initSdk = false
+
   static description = `
 Adds an encrypted key to an encrypted secrets file.
 
@@ -34,21 +36,19 @@ See https://github.com/kuzzleio/kuzzle-vault/ for more information.
   ]
 
   async runSafe() {
-    const { args, flags: userFlags } = this.parse(VaultAdd)
-
-    if (_.isEmpty(userFlags['vault-key'])) {
+    if (_.isEmpty(this.flags['vault-key'])) {
       throw new Error('A vault key must be provided')
     }
 
-    if (_.isEmpty(args['secrets-file'])) {
+    if (_.isEmpty(this.args['secrets-file'])) {
       throw new Error('A secrets file must be provided')
     }
 
-    const cryptonomicon = new Cryptonomicon(userFlags['vault-key'])
+    const cryptonomicon = new Cryptonomicon(this.flags['vault-key'])
 
     let encryptedSecrets = {}
-    if (fs.existsSync(args['secrets-file'])) {
-      encryptedSecrets = JSON.parse(fs.readFileSync(args['secrets-file'], 'utf8'))
+    if (fs.existsSync(this.args['secrets-file'])) {
+      encryptedSecrets = JSON.parse(fs.readFileSync(this.args['secrets-file'], 'utf8'))
 
       try {
         cryptonomicon.decryptObject(encryptedSecrets)
@@ -58,10 +58,10 @@ See https://github.com/kuzzleio/kuzzle-vault/ for more information.
       }
     }
 
-    _.set(encryptedSecrets, args.key, cryptonomicon.encryptString(args.value))
+    _.set(encryptedSecrets, this.args.key, cryptonomicon.encryptString(this.args.value))
 
-    fs.writeFileSync(args['secrets-file'], JSON.stringify(encryptedSecrets, null, 2))
+    fs.writeFileSync(this.args['secrets-file'], JSON.stringify(encryptedSecrets, null, 2))
 
-    this.logOk(`Key "${args.key}" has been securely added "${args['secrets-file']}"`)
+    this.logOk(`Key "${this.args.key}" has been securely added "${this.args['secrets-file']}"`)
   }
 }

--- a/src/commands/vault/decrypt.ts
+++ b/src/commands/vault/decrypt.ts
@@ -6,6 +6,8 @@ import { Cryptonomicon } from 'kuzzle-vault'
 import { Kommand } from '../../common'
 
 export class VaultDecrypt extends Kommand {
+  static initSdk = false
+
   static description = `
 Decrypts an entire secrets file.
 
@@ -39,37 +41,35 @@ See https://github.com/kuzzleio/kuzzle-vault/ for more information.
   ]
 
   async runSafe() {
-    const { args, flags: userFlags } = this.parse(VaultDecrypt)
-
-    if (_.isEmpty(userFlags['vault-key'])) {
+    if (_.isEmpty(this.flags['vault-key'])) {
       throw new Error('A vault key must be provided')
     }
 
-    if (_.isEmpty(args.file)) {
+    if (_.isEmpty(this.args.file)) {
       throw new Error('A secrets file must be provided')
     }
 
-    let outputFile = `${args.file.replace('.enc', '')}`
-    if (userFlags['output-file']) {
-      outputFile = userFlags['output-file']
+    let outputFile = `${this.args.file.replace('.enc', '')}`
+    if (this.flags['output-file']) {
+      outputFile = this.flags['output-file']
     }
 
-    if (fs.existsSync(outputFile) && !userFlags.force) {
+    if (fs.existsSync(outputFile) && !this.flags.force) {
       throw new Error(`Output file "${outputFile}" already exists. Use -f flag to overwrite it.`)
     }
 
-    const cryptonomicon = new Cryptonomicon(userFlags['vault-key'])
+    const cryptonomicon = new Cryptonomicon(this.flags['vault-key'])
 
-    if (!fs.existsSync(args.file)) {
-      throw new Error(`File "${args.file}" does not exists`)
+    if (!fs.existsSync(this.args.file)) {
+      throw new Error(`File "${this.args.file}" does not exists`)
     }
 
     let encryptedSecrets = {}
     try {
-      encryptedSecrets = JSON.parse(fs.readFileSync(args.file, 'utf8'))
+      encryptedSecrets = JSON.parse(fs.readFileSync(this.args.file, 'utf8'))
     }
     catch (error) {
-      throw new Error(`Cannot read secrets from file "${args.file}": ${error.message}`)
+      throw new Error(`Cannot read secrets from file "${this.args.file}": ${error.message}`)
     }
 
     const secrets = cryptonomicon.decryptObject(encryptedSecrets)

--- a/src/commands/vault/encrypt.ts
+++ b/src/commands/vault/encrypt.ts
@@ -6,6 +6,8 @@ import { Cryptonomicon } from 'kuzzle-vault'
 import { Kommand } from '../../common'
 
 export class VaultEncrypt extends Kommand {
+  static initSdk = false
+
   static description = `
 Encrypts an entire secrets file.
 
@@ -50,38 +52,36 @@ See https://github.com/kuzzleio/kuzzle-vault/ for more information.
   ]
 
   async runSafe() {
-    const { args, flags: userFlags } = this.parse(VaultEncrypt)
-
-    if (_.isEmpty(userFlags['vault-key'])) {
+    if (_.isEmpty(this.flags['vault-key'])) {
       throw new Error('A vault key must be provided')
     }
 
-    if (_.isEmpty(args.file)) {
+    if (_.isEmpty(this.args.file)) {
       throw new Error('A secrets file must be provided')
     }
 
-    const [filename, ext] = args.file.split('.')
+    const [filename, ext] = this.args.file.split('.')
     let outputFile = `${filename}.enc.${ext}`
-    if (userFlags['output-file']) {
-      outputFile = userFlags['output-file']
+    if (this.flags['output-file']) {
+      outputFile = this.flags['output-file']
     }
 
-    if (fs.existsSync(outputFile) && !userFlags.force) {
+    if (fs.existsSync(outputFile) && !this.flags.force) {
       throw new Error(`Output file "${outputFile}" already exists. Use -f flag to overwrite it.`)
     }
 
-    const cryptonomicon = new Cryptonomicon(userFlags['vault-key'])
+    const cryptonomicon = new Cryptonomicon(this.flags['vault-key'])
 
-    if (!fs.existsSync(args.file)) {
-      throw new Error(`File "${args.file}" does not exists`)
+    if (!fs.existsSync(this.args.file)) {
+      throw new Error(`File "${this.args.file}" does not exists`)
     }
 
     let secrets = {}
     try {
-      secrets = JSON.parse(fs.readFileSync(args.file, 'utf8'))
+      secrets = JSON.parse(fs.readFileSync(this.args.file, 'utf8'))
     }
     catch (error) {
-      throw new Error(`Cannot read secrets from file "${args.file}": ${error.message}`)
+      throw new Error(`Cannot read secrets from file "${this.args.file}": ${error.message}`)
     }
 
     const encryptedSecrets = cryptonomicon.encryptObject(secrets)

--- a/src/commands/vault/show.ts
+++ b/src/commands/vault/show.ts
@@ -7,6 +7,8 @@ import { Cryptonomicon } from 'kuzzle-vault'
 import { Kommand } from '../../common'
 
 export class VaultShow extends Kommand {
+  static initSdk = false
+
   static description = `
 Prints an encrypted secrets file content.
 
@@ -35,40 +37,38 @@ See https://github.com/kuzzleio/kuzzle-vault/ for more information.
   ]
 
   async runSafe() {
-    const { args, flags: userFlags } = this.parse(VaultShow)
-
-    if (_.isEmpty(userFlags['vault-key'])) {
+    if (_.isEmpty(this.flags['vault-key'])) {
       throw new Error('A vault key must be provided')
     }
 
-    if (_.isEmpty(args['secrets-file'])) {
+    if (_.isEmpty(this.args['secrets-file'])) {
       throw new Error('A secrets file must be provided')
     }
 
-    const cryptonomicon = new Cryptonomicon(userFlags['vault-key'])
+    const cryptonomicon = new Cryptonomicon(this.flags['vault-key'])
 
-    if (!fs.existsSync(args['secrets-file'])) {
-      throw new Error(`File "${args['secrets-file']}" does not exists`)
+    if (!fs.existsSync(this.args['secrets-file'])) {
+      throw new Error(`File "${this.args['secrets-file']}" does not exists`)
     }
 
     let encryptedSecrets = {}
     try {
-      encryptedSecrets = JSON.parse(fs.readFileSync(args['secrets-file'], 'utf8'))
+      encryptedSecrets = JSON.parse(fs.readFileSync(this.args['secrets-file'], 'utf8'))
     }
     catch (error) {
-      throw new Error(`Cannot read secrets from file "${args['secrets-file']}": ${error.message}`)
+      throw new Error(`Cannot read secrets from file "${this.args['secrets-file']}": ${error.message}`)
     }
 
-    if (args.key) {
-      const encryptedValue = _.get(encryptedSecrets, args.key)
+    if (this.args.key) {
+      const encryptedValue = _.get(encryptedSecrets, this.args.key)
 
       if (!encryptedValue) {
-        throw new Error(`Key "${args.key}" does not exist`)
+        throw new Error(`Key "${this.args.key}" does not exist`)
       }
 
       const decryptedValue = cryptonomicon.decryptString(encryptedValue)
 
-      this.logOk(`Key "${args.key}" content:`)
+      this.logOk(`Key "${this.args.key}" content:`)
       this.log(chalk.green(decryptedValue))
     }
     else {

--- a/src/commands/vault/test.ts
+++ b/src/commands/vault/test.ts
@@ -5,6 +5,8 @@ import { Vault } from 'kuzzle-vault'
 import { Kommand } from '../../common'
 
 export class VaultTest extends Kommand {
+  static initSdk = false
+
   static description = `
 Tests if an encrypted secrets file can be decrypted.
 
@@ -27,20 +29,18 @@ See https://github.com/kuzzleio/kuzzle-vault/ for more information.
   ]
 
   async runSafe() {
-    const { args, flags: userFlags } = this.parse(VaultTest)
-
-    if (_.isEmpty(userFlags['vault-key'])) {
+    if (_.isEmpty(this.flags['vault-key'])) {
       throw new Error('A vault key must be provided')
     }
 
-    if (_.isEmpty(args['secrets-file'])) {
+    if (_.isEmpty(this.args['secrets-file'])) {
       throw new Error('A secrets file must be provided')
     }
 
-    const vault = new Vault(userFlags['vault-key'])
+    const vault = new Vault(this.flags['vault-key'])
 
     try {
-      vault.decrypt(args['secrets-file'])
+      vault.decrypt(this.args['secrets-file'])
       this.logOk('Secrets file can be decrypted')
     }
     catch (error) {

--- a/src/common.ts
+++ b/src/common.ts
@@ -27,26 +27,21 @@ export abstract class Kommand extends Command {
     this.log('')
   }
 
-  public log(message?: string | undefined, ...args: any[]): void {
-    return super.log(` ${message}`, ...args)
+  public log(message?: string): void {
+    return super.log(` ${message}`)
   }
 
-  public logOk(message: string, ...args: any[]): void {
-    this.log(chalk.green(`[✔] ${message}`), ...args)
+  public logOk(message: string): void {
+    this.log(chalk.green(`[✔] ${message}`))
   }
 
-  public logInfo(message: string, ...args: any[]): void {
-    this.log(chalk.yellow(`[ℹ] ${message}`), ...args)
+  public logInfo(message: string): void {
+    this.log(chalk.yellow(`[ℹ] ${message}`))
   }
 
-  public logKo(message: string, ...args: any[]): void {
+  public logKo(message?: string): void {
     process.exitCode = 1
-    this.log(chalk.red(`[X] ${message}`), ...args)
-  }
-
-  public logError(message?: string | undefined, ...args: any[]): void {
-    process.exitCode = 1
-    return this.error(chalk.red(`[X] ${message}`), ...args)
+    return this.error(chalk.red(`[X] ${message}`))
   }
 
   async run() {
@@ -66,7 +61,7 @@ export abstract class Kommand extends Command {
       await this.runSafe()
     }
     catch (error) {
-      this.logError(`${error.stack || error.message}\n\tstatus: ${error.status}\n\tid: ${error.id}`)
+      this.logKo(`${error.stack || error.message}\n\tstatus: ${error.status}\n\tid: ${error.id}`)
     }
     finally {
       this.sdk?.disconnect()

--- a/src/support/kuzzle.ts
+++ b/src/support/kuzzle.ts
@@ -31,9 +31,6 @@ export const kuzzleFlags = {
     description: 'Kuzzle protocol (http or websocket)',
     default: process.env.KUZZLE_PROTOCOL || 'http',
   }),
-  as: flags.string({
-    description: 'kuid of a user to impersonate'
-  }),
 }
 
 export class KuzzleSDK {

--- a/src/support/restore-collection.ts
+++ b/src/support/restore-collection.ts
@@ -154,11 +154,11 @@ export async function restoreCollectionMappings(sdk: any, dump: any, index?: str
   const dstIndex: any = index || srcIndex
   const dstCollection: any = collection || srcCollection
 
-  if (!await sdk.index.exists(dstIndex)) {
-    await sdk.index.create(dstIndex)
+  if (!await sdk?.index.exists(dstIndex)) {
+    await sdk?.index.create(dstIndex)
   }
 
-  await sdk.collection.create(dstIndex, dstCollection, dump.content[srcIndex][srcCollection])
+  await sdk?.collection.create(dstIndex, dstCollection, dump.content[srcIndex][srcCollection])
 
   return {
     index: dstIndex,


### PR DESCRIPTION
## What does this PR do?

Refactoring:
 - Use `logOk`, `logInfo` and `logKo` instead of manual call to `chalk.*`
 - Instantiate the SDK in the `Kommand.run` method instead of doing it in every command
 - Parse the args and flags in the `Kommand.run` method instead of doing it in every command
 - Use `path.join` to support windows
 - Rewrite `query` command description

Enhancement
 - Allow to choose the SDK protocol with `--protocol websocket|http`