### PR TITLE
Add user:export and user:import

### DIFF
--- a/README.md
+++ b/README.md
@@ -897,7 +897,7 @@ USAGE
 
 OPTIONS
   --as=as              Impersonate a user
-  --exclude=exclude    [default: []] Exclude user by matching their IDs
+  --exclude=exclude    [default: []] Exclude users by matching their IDs
   --help               show CLI help
   --host=host          [default: localhost] Kuzzle server host
   --password=password  Kuzzle user password

--- a/README.md
+++ b/README.md
@@ -913,7 +913,7 @@ OPTIONS
 DESCRIPTION
   Exports users
 
-  Users credentials are NOT exported but only users content and profiles.
+  Users credentials are NOT exported. Only users' content and profiles are.
 
   See https://docs.kuzzle.io/core/2/guides/essentials/export-import-data.
 ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ npm install -g kourou
 $ kourou COMMAND
 running command...
 $ kourou (-v|--version|version)
-kourou/0.12.0 linux-x64 node-v12.16.0
+kourou/0.12.0 linux-x64 node-v12.16.2
 $ kourou --help [COMMAND]
 USAGE
   $ kourou COMMAND
@@ -909,6 +909,13 @@ OPTIONS
   --protocol=protocol      [default: ws] Kuzzle protocol (http or websocket)
   --ssl                    Use SSL to connect to Kuzzle
   --username=username      [default: anonymous] Kuzzle username (local strategy)
+
+DESCRIPTION
+  Exports users
+
+  Users credentials are NOT exported but only users content and profiles.
+
+  See https://docs.kuzzle.io/core/2/guides/essentials/export-import-data.
 ```
 
 _See code: [src/commands/user/export.ts](https://github.com/kuzzleio/kourou/blob/v0.12.0/src/commands/user/export.ts)_

--- a/README.md
+++ b/README.md
@@ -898,16 +898,17 @@ USAGE
   $ kourou user:export
 
 OPTIONS
-  --as=as              Impersonate a user
-  --exclude=exclude    [default: []] Exclude users by matching their IDs
-  --help               show CLI help
-  --host=host          [default: localhost] Kuzzle server host
-  --password=password  Kuzzle user password
-  --path=path          [default: users] Dump directory
-  --port=port          [default: 7512] Kuzzle server port
-  --protocol=protocol  [default: ws] Kuzzle protocol (http or websocket)
-  --ssl                Use SSL to connect to Kuzzle
-  --username=username  [default: anonymous] Kuzzle username (local strategy)
+  --as=as                  Impersonate a user
+  --batch-size=batch-size  [default: 2000] Maximum batch size (see limits.documentsFetchCount config)
+  --exclude=exclude        [default: []] Exclude users by matching their IDs
+  --help                   show CLI help
+  --host=host              [default: localhost] Kuzzle server host
+  --password=password      Kuzzle user password
+  --path=path              [default: users] Dump directory
+  --port=port              [default: 7512] Kuzzle server port
+  --protocol=protocol      [default: ws] Kuzzle protocol (http or websocket)
+  --ssl                    Use SSL to connect to Kuzzle
+  --username=username      [default: anonymous] Kuzzle username (local strategy)
 ```
 
 _See code: [src/commands/user/export.ts](https://github.com/kuzzleio/kourou/blob/v0.12.0/src/commands/user/export.ts)_

--- a/README.md
+++ b/README.md
@@ -590,6 +590,7 @@ OPTIONS
   --host=host              [default: localhost] Kuzzle server host
   --password=password      Kuzzle user password
   --port=port              [default: 7512] Kuzzle server port
+  --preserve-anonymous     Preserve anonymous rights
   --protocol=protocol      [default: ws] Kuzzle protocol (http or websocket)
   --ssl                    Use SSL to connect to Kuzzle
   --username=username      [default: anonymous] Kuzzle username (local strategy)
@@ -765,14 +766,15 @@ ARGUMENTS
   PATH  Dump file
 
 OPTIONS
-  --as=as              Impersonate a user
-  --help               show CLI help
-  --host=host          [default: localhost] Kuzzle server host
-  --password=password  Kuzzle user password
-  --port=port          [default: 7512] Kuzzle server port
-  --protocol=protocol  [default: ws] Kuzzle protocol (http or websocket)
-  --ssl                Use SSL to connect to Kuzzle
-  --username=username  [default: anonymous] Kuzzle username (local strategy)
+  --as=as               Impersonate a user
+  --help                show CLI help
+  --host=host           [default: localhost] Kuzzle server host
+  --password=password   Kuzzle user password
+  --port=port           [default: 7512] Kuzzle server port
+  --preserve-anonymous  Preserve anonymous rights
+  --protocol=protocol   [default: ws] Kuzzle protocol (http or websocket)
+  --ssl                 Use SSL to connect to Kuzzle
+  --username=username   [default: anonymous] Kuzzle username (local strategy)
 ```
 
 _See code: [src/commands/role/import.ts](https://github.com/kuzzleio/kourou/blob/v0.12.0/src/commands/role/import.ts)_

--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@ $ kourou query auth:getCurrentUser --as gordon --username admin --password admin
 * [`kourou role:import PATH`](#kourou-roleimport-path)
 * [`kourou sdk:execute`](#kourou-sdkexecute)
 * [`kourou sdk:query CONTROLLER:ACTION`](#kourou-sdkquery-controlleraction)
+* [`kourou user:export`](#kourou-userexport)
+* [`kourou user:import PATH`](#kourou-userimport-path)
 * [`kourou vault:add SECRETS-FILE KEY VALUE`](#kourou-vaultadd-secrets-file-key-value)
 * [`kourou vault:decrypt FILE`](#kourou-vaultdecrypt-file)
 * [`kourou vault:encrypt FILE`](#kourou-vaultencrypt-file)
@@ -884,6 +886,53 @@ DESCRIPTION
 ```
 
 _See code: [src/commands/sdk/query.ts](https://github.com/kuzzleio/kourou/blob/v0.12.0/src/commands/sdk/query.ts)_
+
+## `kourou user:export`
+
+Exports users
+
+```
+USAGE
+  $ kourou user:export
+
+OPTIONS
+  --as=as              Impersonate a user
+  --exclude=exclude    [default: []] Exclude user by matching their IDs
+  --help               show CLI help
+  --host=host          [default: localhost] Kuzzle server host
+  --password=password  Kuzzle user password
+  --path=path          [default: users] Dump directory
+  --port=port          [default: 7512] Kuzzle server port
+  --protocol=protocol  [default: ws] Kuzzle protocol (http or websocket)
+  --ssl                Use SSL to connect to Kuzzle
+  --username=username  [default: anonymous] Kuzzle username (local strategy)
+```
+
+_See code: [src/commands/user/export.ts](https://github.com/kuzzleio/kourou/blob/v0.12.0/src/commands/user/export.ts)_
+
+## `kourou user:import PATH`
+
+Imports users
+
+```
+USAGE
+  $ kourou user:import PATH
+
+ARGUMENTS
+  PATH  Dump file
+
+OPTIONS
+  --as=as              Impersonate a user
+  --help               show CLI help
+  --host=host          [default: localhost] Kuzzle server host
+  --password=password  Kuzzle user password
+  --port=port          [default: 7512] Kuzzle server port
+  --protocol=protocol  [default: ws] Kuzzle protocol (http or websocket)
+  --ssl                Use SSL to connect to Kuzzle
+  --username=username  [default: anonymous] Kuzzle username (local strategy)
+```
+
+_See code: [src/commands/user/import.ts](https://github.com/kuzzleio/kourou/blob/v0.12.0/src/commands/user/import.ts)_
 
 ## `kourou vault:add SECRETS-FILE KEY VALUE`
 

--- a/features/Import.feature
+++ b/features/Import.feature
@@ -40,12 +40,25 @@ Feature: Generic Import
     And I delete the role "teacher"
     And I delete the role "student"
 
+    # user export
+    And I create a user "kleiner" with content:
+      | profileIds | ["admin"]              |
+      | email      | "kleiner@blackmesa.us" |
+    And I create a user "alyx" with content:
+      | profileIds | ["admin"]           |
+      | email      | "alyx@blackmesa.us" |
+    When I run the command "user:export" with:
+      | flag | --path    | ./dump                   |
+      | flag | --exclude | ["gordon", "test-admin"] |
+    And I delete the user "kleiner"
+    And I delete the user "alyx"
+
 
     # import
     And I run the command "import" with:
       | arg | ./dump |  |
 
-    # check index & collections import
+    # Check index & collections import
     Then The document "chuon-chuon-kim2" content match:
       | city     | "hcmc" |
       | district | 1      |
@@ -66,14 +79,22 @@ Feature: Generic Import
       | city | { "type": "keyword" } |
       | name | { "type": "keyword" } |
 
-    # check role import
+    # Check role import
     Then The role "teacher" should match:
       | document | { "actions": { "create": true } } |
     And The role "student" should match:
       | document | { "actions": { "update": true } } |
 
-    # check profile import
+    # Check profile import
     Then The profile "teacher" should match:
       | default | [{ "index": "nyc-open-data" }] |
     And The profile "student" should match:
       | admin | [{ "index": "mtp-open-data" }] |
+
+    # Check user import
+    Then The user "kleiner" should match:
+      | profileIds | ["admin"]              |
+      | email      | "kleiner@blackmesa.us" |
+    And The user "alyx" should match:
+      | profileIds | ["admin"]           |
+      | email      | "alyx@blackmesa.us" |

--- a/features/User.feature
+++ b/features/User.feature
@@ -1,0 +1,27 @@
+Feature: User Commands
+
+  # user:export & user:import ==================================================
+
+  @security
+  Scenario: Export and import users
+    Given I create a user "kleiner" with content:
+      | profileIds | ["admin"]              |
+      | email      | "kleiner@blackmesa.us" |
+    And I create a user "alyx" with content:
+      | profileIds | ["admin"]           |
+      | email      | "alyx@blackmesa.us" |
+    When I run the command "user:export" with:
+      | flag | --path    | ./dump                   |
+      | flag | --exclude | ["gordon", "test-admin"] |
+    And I delete the user "kleiner"
+    And I delete the user "alyx"
+    When I run the command "user:import" with:
+      | arg | ./dump/users.json |  |
+    Then The user "kleiner" should match:
+      | profileIds | ["admin"]              |
+      | email      | "kleiner@blackmesa.us" |
+    And The user "alyx" should match:
+      | profileIds | ["admin"]           |
+      | email      | "alyx@blackmesa.us" |
+
+

--- a/features/step_definitions/common/security-steps.js
+++ b/features/step_definitions/common/security-steps.js
@@ -17,13 +17,13 @@ Given('I create a profile {string} with the following policies:', async function
 Given('I create a role {string} with the following API rights:', async function (roleId, dataTable) {
 
   const controllers = this.parseObject(dataTable);
-  this.props.result = await this.sdk.security.createRole(roleId, { controllers }, { refresh: 'wait_for' });
+  this.props.result = await this.sdk.security.createRole(roleId, { controllers });
 });
 
 Then(/I (can not )?delete the role "(.*?)"/, async function (not, roleId) {
 
   try {
-    await this.sdk.security.deleteRole(roleId, { refresh: 'wait_for' });
+    await this.sdk.security.deleteRole(roleId);
   }
   catch (e) {
     if (not) {
@@ -35,7 +35,7 @@ Then(/I (can not )?delete the role "(.*?)"/, async function (not, roleId) {
 
 Then(/I (can not )?delete the profile "(.*?)"/, async function (not, profileId) {
   try {
-    await this.sdk.security.deleteProfile(profileId, { refresh: 'wait_for' });
+    await this.sdk.security.deleteProfile(profileId);
   }
   catch (e) {
     if (not) {
@@ -46,7 +46,7 @@ Then(/I (can not )?delete the profile "(.*?)"/, async function (not, profileId) 
 });
 
 Given('I delete the user {string}', async function (userId) {
-  this.props.result = await this.sdk.security.deleteUser(userId, { refresh: 'wait_for' });
+  this.props.result = await this.sdk.security.deleteUser(userId);
 });
 
 Given('I create a user {string} with content:', async function (userId, dataTable) {
@@ -103,4 +103,11 @@ Given('The role {string} should match:', async function (roleId, dataTable) {
   const role = await this.sdk.security.getRole(roleId);
 
   should(role.controllers).match(expectedControllers);
+})
+
+Given('The user {string} should match:', async function (userId, dataTable) {
+  const expectedContent = this.parseObject(dataTable);
+  const user = await this.sdk.security.getUser(userId);
+
+  should(user.content).match(expectedContent);
 })

--- a/src/commands/collection/import.ts
+++ b/src/commands/collection/import.ts
@@ -49,7 +49,7 @@ export default class CollectionImport extends Kommand {
         this.flags.collection)
     }
 
-    const { total } = await restoreCollectionData(
+    const { index, collection, total } = await restoreCollectionData(
       this.sdk,
       this.log.bind(this),
       Number(this.flags['batch-size']),
@@ -57,6 +57,6 @@ export default class CollectionImport extends Kommand {
       this.flags.index,
       this.flags.collection)
 
-    this.logOk(`Successfully imported ${total} documents from "${this.args.path}" in "${this.flags.index}:${this.flags.collection}"`)
+    this.logOk(`Successfully imported ${total} documents from "${this.args.path}" in "${index}:${collection}"`)
   }
 }

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -5,7 +5,7 @@ import * as path from 'path'
 import { Kommand } from '../common'
 import { kuzzleFlags } from '../support/kuzzle'
 import { restoreCollectionData, restoreCollectionMappings } from '../support/restore-collection'
-import { restoreProfiles, restoreRoles } from '../support/restore-securities'
+import { restoreProfiles, restoreRoles, restoreUsers } from '../support/restore-securities'
 
 const revAlphaSort = (a: string, b: string) => {
   if (a < b) {
@@ -90,6 +90,11 @@ export default class Import extends Kommand {
           this.logInfo(`[profiles] Start importing profiles in ${file}`)
           const total = await restoreProfiles(this.sdk, dump)
           this.logOk(`[profiles] Imported ${total} profiles`)
+        }
+        else if (dump.type === 'users') {
+          this.logInfo(`[users] Start importing users in ${file}`)
+          const total = await restoreUsers(this.sdk, dump)
+          this.logOk(`[users] Imported ${total} users`)
         }
         else if (dump.type === 'mappings') {
           this.logInfo(`[collection] Start importing mappings in ${file}`)

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -7,22 +7,14 @@ import { kuzzleFlags } from '../support/kuzzle'
 import { restoreCollectionData, restoreCollectionMappings } from '../support/restore-collection'
 import { restoreProfiles, restoreRoles, restoreUsers } from '../support/restore-securities'
 
-const revAlphaSort = (a: string, b: string) => {
-  if (a < b) {
-    return 1
-  }
-
-  if (a > b) {
-    return -1
-  }
-
-  return 0
-}
-
 export default class Import extends Kommand {
   static description = 'Recursively imports dump files from a root directory'
 
   static flags = {
+    'preserve-anonymous': flags.boolean({
+      description: 'Preserve anonymous rights',
+      default: false
+    }),
     help: flags.help({}),
     'batch-size': flags.string({
       description: 'Maximum batch size (see limits.documentsWriteCount config)',
@@ -40,7 +32,80 @@ export default class Import extends Kommand {
   ]
 
   async runSafe() {
-    await this.walkDirectories(this.args.path)
+    const files = await this.walkDirectories(this.args.path)
+
+    for (const file of files.mappings) {
+      try {
+        this.logInfo(`[collection] Start importing mappings in ${file}`)
+
+        const dump = JSON.parse(fs.readFileSync(file, 'utf8'))
+        const { index, collection } = await restoreCollectionMappings(this.sdk, dump)
+
+        this.logOk(`[collection] Imported mappings for "${index}":"${collection}"`)
+      }
+      catch (error) {
+        this.logKo(`Error during import of ${file}: ${error.message}. Skipped.`)
+      }
+    }
+
+    for (const file of files.documents) {
+      try {
+        this.logInfo(`[collection] Start importing documents in ${file}`)
+
+        const { total, index, collection } = await restoreCollectionData(
+          this.sdk,
+          this.log.bind(this),
+          Number(this.flags['batch-size']),
+          file)
+
+        this.logOk(`[collection] Imported ${total} documents in "${index}":"${collection}"`)
+      }
+      catch (error) {
+        this.logKo(`Error during import of ${file}: ${error.message}. Skipped.`)
+      }
+    }
+
+    for (const file of files.roles) {
+      try {
+        this.logInfo(`[roles] Start importing roles in ${file}`)
+
+        const dump = JSON.parse(fs.readFileSync(file, 'utf8'))
+        const total = await restoreRoles(this, dump, this.flags['preserve-anonymous'])
+
+        this.logOk(`[roles] Imported ${total} roles`)
+      }
+      catch (error) {
+        this.logKo(`Error during import of ${file}: ${error.message}. Skipped.`)
+      }
+    }
+
+    for (const file of files.profiles) {
+      try {
+        this.logInfo(`[profiles] Start importing profiles in ${file}`)
+
+        const dump = JSON.parse(fs.readFileSync(file, 'utf8'))
+        const total = await restoreProfiles(this, dump)
+
+        this.logOk(`[profiles] Imported ${total} profiles`)
+      }
+      catch (error) {
+        this.logKo(`Error during import of ${file}: ${error.message}. Skipped.`)
+      }
+    }
+
+    for (const file of files.users) {
+      try {
+        this.logInfo(`[users] Start importing users in ${file}`)
+
+        const dump = JSON.parse(fs.readFileSync(file, 'utf8'))
+        const total = await restoreUsers(this, dump)
+
+        this.logOk(`[users] Imported ${total} users`)
+      }
+      catch (error) {
+        this.logKo(`Error during import of ${file}: ${error.message}. Skipped.`)
+      }
+    }
   }
 
   async walkDirectories(directory: string) {
@@ -49,20 +114,44 @@ export default class Import extends Kommand {
     const directories = entries
       .map(entry => path.join(directory, entry))
       .filter(dirName => fs.lstatSync(dirName).isDirectory())
-      .sort(revAlphaSort)
 
-    // Sort files by name some mappings.json come before documents.jsonl
     const files = entries
       .map(entry => path.join(directory, entry))
       .filter(fileName => fs.lstatSync(fileName).isFile())
-      .sort(revAlphaSort)
+      .reduce((memo: any, file: string) => {
+        const fileType = this.getFileType(file)
 
-    for (const file of files) {
-      await this.importFile(file)
-    }
+        memo[fileType].push(file)
+
+        return memo
+      }, { documents: [], mappings: [], roles: [], profiles: [], users: [] })
+
 
     for (const dir of directories) {
-      await this.walkDirectories(dir)
+      const { documents, mappings, roles, profiles, users } = await this.walkDirectories(dir)
+      files.documents = files.documents.concat(documents)
+      files.mappings = files.mappings.concat(mappings)
+      files.roles = files.roles.concat(roles)
+      files.profiles = files.profiles.concat(profiles)
+      files.users = files.users.concat(users)
+    }
+
+    return files
+  }
+
+  getFileType(file: string) {
+    if (file.endsWith('.jsonl')) {
+      return 'documents'
+    }
+    else if (file.endsWith('.json')) {
+      try {
+        const dump = JSON.parse(fs.readFileSync(file, 'utf8'))
+
+        return dump.type
+      }
+      catch (error) {
+        this.logKo(`Invalid JSON file "${file}". Import skipped. ${error.message}`)
+      }
     }
   }
 
@@ -83,17 +172,17 @@ export default class Import extends Kommand {
 
         if (dump.type === 'roles') {
           this.logInfo(`[roles] Start importing roles in ${file}`)
-          const total = await restoreRoles(this.sdk, dump)
+          const total = await restoreRoles(this, dump, this.flags['preserve-anonymous'])
           this.logOk(`[roles] Imported ${total} roles`)
         }
         else if (dump.type === 'profiles') {
           this.logInfo(`[profiles] Start importing profiles in ${file}`)
-          const total = await restoreProfiles(this.sdk, dump)
+          const total = await restoreProfiles(this, dump)
           this.logOk(`[profiles] Imported ${total} profiles`)
         }
         else if (dump.type === 'users') {
           this.logInfo(`[users] Start importing users in ${file}`)
-          const total = await restoreUsers(this.sdk, dump)
+          const total = await restoreUsers(this, dump)
           this.logOk(`[users] Imported ${total} users`)
         }
         else if (dump.type === 'mappings') {

--- a/src/commands/import.ts
+++ b/src/commands/import.ts
@@ -126,9 +126,9 @@ export default class Import extends Kommand {
         return memo
       }, { documents: [], mappings: [], roles: [], profiles: [], users: [] })
 
-
     for (const dir of directories) {
       const { documents, mappings, roles, profiles, users } = await this.walkDirectories(dir)
+
       files.documents = files.documents.concat(documents)
       files.mappings = files.mappings.concat(mappings)
       files.roles = files.roles.concat(roles)
@@ -143,57 +143,14 @@ export default class Import extends Kommand {
     if (file.endsWith('.jsonl')) {
       return 'documents'
     }
-    else if (file.endsWith('.json')) {
-      try {
-        const dump = JSON.parse(fs.readFileSync(file, 'utf8'))
 
-        return dump.type
-      }
-      catch (error) {
-        this.logKo(`Invalid JSON file "${file}". Import skipped. ${error.message}`)
-      }
+    try {
+      const dump = JSON.parse(fs.readFileSync(file, 'utf8'))
+
+      return dump.type
     }
-  }
-
-  async importFile(file: string) {
-    if (file.endsWith('.jsonl')) {
-      this.logInfo(`[collection] Start importing documents in ${file}`)
-      const { total, index, collection } = await restoreCollectionData(
-        this.sdk,
-        this.log.bind(this),
-        Number(this.flags['batch-size']),
-        file)
-
-      this.logOk(`[collection] Imported ${total} documents in "${index}":"${collection}"`)
-    }
-    else if (file.endsWith('.json')) {
-      try {
-        const dump = JSON.parse(fs.readFileSync(file, 'utf8'))
-
-        if (dump.type === 'roles') {
-          this.logInfo(`[roles] Start importing roles in ${file}`)
-          const total = await restoreRoles(this, dump, this.flags['preserve-anonymous'])
-          this.logOk(`[roles] Imported ${total} roles`)
-        }
-        else if (dump.type === 'profiles') {
-          this.logInfo(`[profiles] Start importing profiles in ${file}`)
-          const total = await restoreProfiles(this, dump)
-          this.logOk(`[profiles] Imported ${total} profiles`)
-        }
-        else if (dump.type === 'users') {
-          this.logInfo(`[users] Start importing users in ${file}`)
-          const total = await restoreUsers(this, dump)
-          this.logOk(`[users] Imported ${total} users`)
-        }
-        else if (dump.type === 'mappings') {
-          this.logInfo(`[collection] Start importing mappings in ${file}`)
-          const { index, collection } = await restoreCollectionMappings(this.sdk, dump)
-          this.logOk(`[collection] Imported mappings for "${index}":"${collection}"`)
-        }
-      }
-      catch (error) {
-        this.logKo(`Invalid JSON file "${file}". Import skipped. ${error.message}`)
-      }
+    catch (error) {
+      this.logKo(`Invalid JSON file "${file}". Import skipped. ${error.message}`)
     }
   }
 }

--- a/src/commands/profile/import.ts
+++ b/src/commands/profile/import.ts
@@ -26,7 +26,7 @@ export default class ProfileImport extends Kommand {
 
     const dump = JSON.parse(fs.readFileSync(this.args.path, 'utf-8'))
 
-    const count = await restoreProfiles(this.sdk, dump)
+    const count = await restoreProfiles(this, dump)
 
     this.logOk(`${count} profiles restored`)
   }

--- a/src/commands/role/import.ts
+++ b/src/commands/role/import.ts
@@ -8,6 +8,10 @@ export default class RoleImport extends Kommand {
   static description = 'Import roles'
 
   static flags = {
+    'preserve-anonymous': flags.boolean({
+      description: 'Preserve anonymous rights',
+      default: false
+    }),
     help: flags.help({}),
     ...kuzzleFlags,
     protocol: flags.string({
@@ -25,7 +29,7 @@ export default class RoleImport extends Kommand {
 
     const dump = JSON.parse(fs.readFileSync(this.args.path, 'utf-8'))
 
-    const count = await restoreRoles(this.sdk, dump)
+    const count = await restoreRoles(this, dump, this.flags['preserve-anonymous'])
 
     this.logOk(`${count} roles restored`)
   }

--- a/src/commands/user/export.ts
+++ b/src/commands/user/export.ts
@@ -16,7 +16,7 @@ export default class UserExport extends Kommand {
       default: 'users'
     }),
     exclude: flags.string({
-      description: 'Exclude user by matching their IDs',
+      description: 'Exclude users by matching their IDs',
       default: '[]'
     }),
     ...kuzzleFlags,

--- a/src/commands/user/export.ts
+++ b/src/commands/user/export.ts
@@ -1,0 +1,75 @@
+import * as fs from 'fs'
+import * as _ from 'lodash'
+import path from 'path'
+
+import { flags } from '@oclif/command'
+import { Kommand } from '../../common'
+import { kuzzleFlags, } from '../../support/kuzzle'
+
+export default class UserExport extends Kommand {
+  static description = 'Exports users'
+
+  static flags = {
+    help: flags.help({}),
+    path: flags.string({
+      description: 'Dump directory',
+      default: 'users'
+    }),
+    exclude: flags.string({
+      description: 'Exclude user by matching their IDs',
+      default: '[]'
+    }),
+    ...kuzzleFlags,
+    protocol: flags.string({
+      description: 'Kuzzle protocol (http or websocket)',
+      default: 'ws',
+    }),
+  }
+
+  private excludes: string[] = []
+
+  async runSafe() {
+    const filename = path.join(this.flags.path, 'users.json')
+
+    this.logInfo(`Exporting users in ${filename} ...`)
+
+    fs.mkdirSync(this.flags.path, { recursive: true })
+
+    this.excludes = this.parseJs(this.flags.exclude)
+
+    const users = await this._dumpUsers()
+
+    const dump = {
+      type: 'users',
+      content: users
+    }
+
+    fs.writeFileSync(filename, JSON.stringify(dump, null, 2))
+
+    this.logOk(`${Object.keys(users).length} users dumped`)
+  }
+
+  async _dumpUsers() {
+    const users: any = {}
+
+    let results = await this.sdk?.security.searchUsers(
+      {},
+      { scroll: '5s', size: 100 })
+
+    while (results) {
+      for (const user of results.hits) {
+        const shouldInclude = this.excludes.every((exclude: string) => (
+          !user._id.match(new RegExp(exclude))
+        ))
+
+        if (shouldInclude) {
+          users[user._id] = _.omit(user.content, ['_kuzzle_info'])
+        }
+      }
+
+      results = await results.next()
+    }
+
+    return users
+  }
+}

--- a/src/commands/user/export.ts
+++ b/src/commands/user/export.ts
@@ -19,6 +19,10 @@ export default class UserExport extends Kommand {
       description: 'Exclude users by matching their IDs',
       default: '[]'
     }),
+    'batch-size': flags.string({
+      description: 'Maximum batch size (see limits.documentsFetchCount config)',
+      default: '2000'
+    }),
     ...kuzzleFlags,
     protocol: flags.string({
       description: 'Kuzzle protocol (http or websocket)',
@@ -54,7 +58,7 @@ export default class UserExport extends Kommand {
 
     let results = await this.sdk?.security.searchUsers(
       {},
-      { scroll: '5s', size: 100 })
+      { scroll: '5s', size: this.flags['batch-size'] })
 
     while (results) {
       for (const user of results.hits) {

--- a/src/commands/user/import.ts
+++ b/src/commands/user/import.ts
@@ -26,7 +26,7 @@ export default class UserImport extends Kommand {
 
     const dump = JSON.parse(fs.readFileSync(this.args.path, 'utf-8'))
 
-    const count = await restoreUsers(this.sdk, dump)
+    const count = await restoreUsers(this, dump)
 
     this.logOk(`${count} users restored`)
   }

--- a/src/commands/user/import.ts
+++ b/src/commands/user/import.ts
@@ -1,0 +1,33 @@
+import { flags } from '@oclif/command'
+import * as fs from 'fs'
+
+import { Kommand } from '../../common'
+import { kuzzleFlags } from '../../support/kuzzle'
+import { restoreUsers } from '../../support/restore-securities'
+
+export default class UserImport extends Kommand {
+  static description = 'Imports users'
+
+  static flags = {
+    help: flags.help({}),
+    ...kuzzleFlags,
+    protocol: flags.string({
+      description: 'Kuzzle protocol (http or websocket)',
+      default: 'ws',
+    }),
+  }
+
+  static args = [
+    { name: 'path', description: 'Dump file', required: true },
+  ]
+
+  async runSafe() {
+    this.logInfo(`Importing users from ${this.args.path} ...`)
+
+    const dump = JSON.parse(fs.readFileSync(this.args.path, 'utf-8'))
+
+    const count = await restoreUsers(this.sdk, dump)
+
+    this.logOk(`${count} users restored`)
+  }
+}

--- a/src/support/restore-securities.ts
+++ b/src/support/restore-securities.ts
@@ -1,6 +1,6 @@
 export async function restoreRoles(sdk: any, dump: any) {
   if (dump.type !== 'roles') {
-    throw new Error('Dump file does not contains roles definition')
+    throw new Error('Dump file does not contain roles definition')
   }
 
   const promises = Object.entries(dump.content)
@@ -15,13 +15,30 @@ export async function restoreRoles(sdk: any, dump: any) {
 
 export async function restoreProfiles(sdk: any, dump: any) {
   if (dump.type !== 'profiles') {
-    throw new Error('Dump file does not contains roles definition')
+    throw new Error('Dump file does not contain profiles definition')
   }
 
   const promises = Object.entries(dump.content)
     .map(([profileId, profile]) => (
       sdk.security.createOrReplaceProfile(profileId, profile, { force: true })
     ))
+
+  await Promise.all(promises)
+
+  return promises.length
+}
+
+export async function restoreUsers(sdk: any, dump: any) {
+  if (dump.type !== 'users') {
+    throw new Error('Dump file does not contain users definition')
+  }
+
+  const promises = Object.entries(dump.content)
+    .map(([userId, content]) => (
+      sdk.security.createUser(userId, { content })
+    ))
+
+  await Promise.all(promises)
 
   return promises.length
 }

--- a/src/support/restore-securities.ts
+++ b/src/support/restore-securities.ts
@@ -1,11 +1,38 @@
-export async function restoreRoles(sdk: any, dump: any) {
+import * as _ from 'lodash'
+
+const sleep = (seconds: number) => new Promise((resolve: any) => setTimeout(resolve, seconds * 1000))
+
+export async function restoreRoles(command: any, dump: any, preserveAnonymous: boolean = false) {
   if (dump.type !== 'roles') {
     throw new Error('Dump file does not contain roles definition')
   }
 
+  const anonymousRights = _.get(dump.content, 'anonymous.controllers.*.actions.*')
+
+  if (!preserveAnonymous && anonymousRights === false) {
+    if (command.sdk.username === 'anonymous') {
+      command.logKo('You are currently loggued as "anonymous" and anonymous role write will be overwritten.')
+      command.logInfo('Use the --preserve-anonymous flag to keep default anonymous rights.')
+
+      throw new Error('Please authenticate before importing or use --preserve-anonymous.')
+    }
+    else {
+      command.logInfo('Anonymous user rights will be overwritten.')
+      command.logInfo('Use the --preserve-anonymous flag to keep default anonymous rights.')
+      command.logInfo('Press CTRL+C to abort or wait 4 sec')
+
+      await sleep(4)
+    }
+  }
+  else if (preserveAnonymous) {
+    command.logInfo('Anonymous user rights has been preserved.')
+
+    delete dump.content.anonymous
+  }
+
   const promises = Object.entries(dump.content)
     .map(([roleId, role]) => (
-      sdk.security.createOrReplaceRole(roleId, role, { force: true })
+      command.sdk.security.createOrReplaceRole(roleId, role, { force: true })
     ))
 
   await Promise.all(promises)
@@ -13,14 +40,14 @@ export async function restoreRoles(sdk: any, dump: any) {
   return promises.length
 }
 
-export async function restoreProfiles(sdk: any, dump: any) {
+export async function restoreProfiles(command: any, dump: any) {
   if (dump.type !== 'profiles') {
     throw new Error('Dump file does not contain profiles definition')
   }
 
   const promises = Object.entries(dump.content)
     .map(([profileId, profile]) => (
-      sdk.security.createOrReplaceProfile(profileId, profile, { force: true })
+      command.sdk.security.createOrReplaceProfile(profileId, profile, { force: true })
     ))
 
   await Promise.all(promises)
@@ -28,17 +55,19 @@ export async function restoreProfiles(sdk: any, dump: any) {
   return promises.length
 }
 
-export async function restoreUsers(sdk: any, dump: any) {
+export async function restoreUsers(command: any, dump: any) {
   if (dump.type !== 'users') {
     throw new Error('Dump file does not contain users definition')
   }
 
   const promises = Object.entries(dump.content)
-    .map(([userId, content]) => (
-      sdk.security.createUser(userId, { content })
-    ))
+    .map(([userId, content]) => {
+      return command.sdk.security.createUser(userId, { content })
+        .then(() => true)
+        .catch((error: any) => command.logKo(`Error importing user ${userId}: ${error.message}`))
+    })
 
-  await Promise.all(promises)
+  const results = await Promise.all(promises)
 
-  return promises.length
+  return results.filter(success => success).length
 }

--- a/src/support/restore-securities.ts
+++ b/src/support/restore-securities.ts
@@ -2,7 +2,7 @@ import * as _ from 'lodash'
 
 const sleep = (seconds: number) => new Promise((resolve: any) => setTimeout(resolve, seconds * 1000))
 
-export async function restoreRoles(command: any, dump: any, preserveAnonymous = false) {
+export async function restoreRoles(kommand: any, dump: any, preserveAnonymous = false) {
   if (dump.type !== 'roles') {
     throw new Error('Dump file does not contain roles definition')
   }
@@ -10,29 +10,29 @@ export async function restoreRoles(command: any, dump: any, preserveAnonymous = 
   const anonymousRights = _.get(dump.content, 'anonymous.controllers.*.actions.*')
 
   if (!preserveAnonymous && anonymousRights === false) {
-    if (command.sdk.username === 'anonymous') {
-      command.logKo('You are currently logged in as "anonymous" and anonymous role rights will be overwritten.')
-      command.logInfo('Use the --preserve-anonymous flag to keep the default anonymous rights.')
+    if (kommand.sdk.username === 'anonymous') {
+      kommand.logKo('You are currently logged in as "anonymous" and anonymous role rights will be overwritten.')
+      kommand.logInfo('Use the --preserve-anonymous flag to keep the default anonymous rights.')
 
       throw new Error('Please authenticate before importing or use --preserve-anonymous.')
     }
     else {
-      command.logInfo('Anonymous user rights will be overwritten.')
-      command.logInfo('Use the --preserve-anonymous flag to keep default anonymous rights.')
-      command.logInfo('Press CTRL+C to abort or wait 4 sec')
+      kommand.logInfo('Anonymous user rights will be overwritten.')
+      kommand.logInfo('Use the --preserve-anonymous flag to keep default anonymous rights.')
+      kommand.logInfo('Press CTRL+C to abort or wait 4 sec')
 
       await sleep(4)
     }
   }
   else if (preserveAnonymous) {
-    command.logInfo('Anonymous user rights has been preserved.')
+    kommand.logInfo('Anonymous user rights has been preserved.')
 
     delete dump.content.anonymous
   }
 
   const promises = Object.entries(dump.content)
     .map(([roleId, role]) => (
-      command.sdk.security.createOrReplaceRole(roleId, role, { force: true })
+      kommand.sdk.security.createOrReplaceRole(roleId, role, { force: true })
     ))
 
   await Promise.all(promises)
@@ -40,14 +40,14 @@ export async function restoreRoles(command: any, dump: any, preserveAnonymous = 
   return promises.length
 }
 
-export async function restoreProfiles(command: any, dump: any) {
+export async function restoreProfiles(kommand: any, dump: any) {
   if (dump.type !== 'profiles') {
     throw new Error('Dump file does not contain profiles definition')
   }
 
   const promises = Object.entries(dump.content)
     .map(([profileId, profile]) => (
-      command.sdk.security.createOrReplaceProfile(profileId, profile, { force: true })
+      kommand.sdk.security.createOrReplaceProfile(profileId, profile, { force: true })
     ))
 
   await Promise.all(promises)
@@ -55,16 +55,16 @@ export async function restoreProfiles(command: any, dump: any) {
   return promises.length
 }
 
-export async function restoreUsers(command: any, dump: any) {
+export async function restoreUsers(kommand: any, dump: any) {
   if (dump.type !== 'users') {
     throw new Error('Dump file does not contain users definition')
   }
 
   const promises = Object.entries(dump.content)
     .map(([userId, content]) => {
-      return command.sdk.security.createUser(userId, { content })
+      return kommand.sdk.security.createUser(userId, { content })
         .then(() => true)
-        .catch((error: any) => command.logKo(`Error importing user ${userId}: ${error.message}`))
+        .catch((error: any) => kommand.logKo(`Error importing user ${userId}: ${error.message}`))
     })
 
   const results = await Promise.all(promises)

--- a/src/support/restore-securities.ts
+++ b/src/support/restore-securities.ts
@@ -11,8 +11,8 @@ export async function restoreRoles(command: any, dump: any, preserveAnonymous = 
 
   if (!preserveAnonymous && anonymousRights === false) {
     if (command.sdk.username === 'anonymous') {
-      command.logKo('You are currently loggued as "anonymous" and anonymous role write will be overwritten.')
-      command.logInfo('Use the --preserve-anonymous flag to keep default anonymous rights.')
+      command.logKo('You are currently logged in as "anonymous" and anonymous role rights will be overwritten.')
+      command.logInfo('Use the --preserve-anonymous flag to keep the default anonymous rights.')
 
       throw new Error('Please authenticate before importing or use --preserve-anonymous.')
     }

--- a/src/support/restore-securities.ts
+++ b/src/support/restore-securities.ts
@@ -2,7 +2,7 @@ import * as _ from 'lodash'
 
 const sleep = (seconds: number) => new Promise((resolve: any) => setTimeout(resolve, seconds * 1000))
 
-export async function restoreRoles(command: any, dump: any, preserveAnonymous: boolean = false) {
+export async function restoreRoles(command: any, dump: any, preserveAnonymous = false) {
   if (dump.type !== 'roles') {
     throw new Error('Dump file does not contain roles definition')
   }


### PR DESCRIPTION
## What does this PR do?

This PR adds two commands to export and import users.  
User are not exported with their credentials since Kuzzle can't access them.

It is still useful to export users and then we can either create credentials for them or ask them to recreate a password (thanks to the new password policies)

Also add the users import to the global `import` command

```
USAGE
  $ kourou user:import PATH

ARGUMENTS
  PATH  Dump file

OPTIONS
  --as=as              Impersonate a user
  --help               show CLI help
  --host=host          [default: localhost] Kuzzle server host
  --password=password  Kuzzle user password
  --port=port          [default: 7512] Kuzzle server port
  --protocol=protocol  [default: ws] Kuzzle protocol (http or websocket)
  --ssl                Use SSL to connect to Kuzzle
  --username=username  [default: anonymous] Kuzzle username (local strategy)
```

```
USAGE
  $ kourou user:export

OPTIONS
  --as=as              Impersonate a user
  --exclude=exclude    [default: []] Exclude user by matching their IDs
  --help               show CLI help
  --host=host          [default: localhost] Kuzzle server host
  --password=password  Kuzzle user password
  --path=path          [default: users] Dump directory
  --port=port          [default: 7512] Kuzzle server port
  --protocol=protocol  [default: ws] Kuzzle protocol (http or websocket)
  --ssl                Use SSL to connect to Kuzzle
  --username=username  [default: anonymous] Kuzzle username (local strategy)
```

### How should this be manually tested?

Run the tests

### Other changes

 - fix waiting of `restoreUsers` promises
 - fix global import command 

### Boyscout

 - default value for refresh in the security controller is already `wait_for`
