### PR TITLE
Fix sdk:execute from stdin

### DIFF
--- a/src/commands/sdk/execute.ts
+++ b/src/commands/sdk/execute.ts
@@ -55,6 +55,7 @@ Other
   };
 
   private code = ''
+  static readStdin = true
 
   async beforeConnect() {
     this.code = this.stdin || this.flags.code || '// paste your code here'

--- a/src/commands/sdk/execute.ts
+++ b/src/commands/sdk/execute.ts
@@ -1,4 +1,5 @@
 import { flags } from '@oclif/command'
+import { isEmpty } from 'lodash'
 
 import { Editor } from '../../support/editor'
 import { Kommand } from '../../common'
@@ -55,6 +56,7 @@ Other
   };
 
   private code = ''
+
   static readStdin = true
 
   async beforeConnect() {
@@ -66,6 +68,10 @@ Other
   }
 
   async runSafe() {
+    if (isEmpty(this.code)) {
+      throw new Error('No code provided.')
+    }
+
     let userError: Error | null = null
 
     const variables = (this.flags.var || [])


### PR DESCRIPTION
## What does this PR do?

Fix `sdk:execute` command with code from STDIN.

(There is no functional test because Cucumber mess with stdin so I can't use it as an input)

### How should this be manually tested?

  - Step 1 : `cat "return sdk.server.now()" > code.js`
  - Step 2 : `./bin/run sdk:execute < code.ks`