### PR TITLE
[fix] readme links should be relative

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,9 +64,9 @@ User impersonation require the following rights for the authenticated user: `sec
 
 ```bash
 $ kourou sdk:query auth:getCurrentUser --as gordon --username admin --password admin
- 
+
  🚀 Kourou - Executes an API query.
- 
+
  [ℹ] Connecting to http://localhost:7512 ...
  [ℹ] Impersonate user "gordon"
 
@@ -139,7 +139,7 @@ EXAMPLE
   kourou api-key:check eyJhbG...QxfQrc
 ```
 
-_See code: [src/commands/api-key/check.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/api-key/check.ts)_
+_See code: [src/commands/api-key/check.ts](src/commands/api-key/check.ts)_
 
 ## `kourou api-key:create USER`
 
@@ -166,7 +166,7 @@ OPTIONS
   --username=username            [default: anonymous] Kuzzle username (local strategy)
 ```
 
-_See code: [src/commands/api-key/create.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/api-key/create.ts)_
+_See code: [src/commands/api-key/create.ts](src/commands/api-key/create.ts)_
 
 ## `kourou api-key:delete USER ID`
 
@@ -194,7 +194,7 @@ EXAMPLE
   kourou vault:delete sigfox-gateway 1k-BF3EBjsXdvA2PR8x
 ```
 
-_See code: [src/commands/api-key/delete.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/api-key/delete.ts)_
+_See code: [src/commands/api-key/delete.ts](src/commands/api-key/delete.ts)_
 
 ## `kourou api-key:search USER`
 
@@ -219,7 +219,7 @@ OPTIONS
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 ```
 
-_See code: [src/commands/api-key/search.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/api-key/search.ts)_
+_See code: [src/commands/api-key/search.ts](src/commands/api-key/search.ts)_
 
 ## `kourou collection:create INDEX COLLECTION`
 
@@ -254,7 +254,7 @@ OPTIONS
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 ```
 
-_See code: [src/commands/collection/create.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/collection/create.ts)_
+_See code: [src/commands/collection/create.ts](src/commands/collection/create.ts)_
 
 ## `kourou collection:export INDEX COLLECTION`
 
@@ -287,7 +287,7 @@ EXAMPLES
   kourou collection:export nyc-open-data yellow-taxi --query '{ term: { city: "Saigon" } }'
 ```
 
-_See code: [src/commands/collection/export.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/collection/export.ts)_
+_See code: [src/commands/collection/export.ts](src/commands/collection/export.ts)_
 
 ## `kourou collection:import PATH`
 
@@ -315,7 +315,7 @@ OPTIONS
   --username=username      [default: anonymous] Kuzzle username (local strategy)
 ```
 
-_See code: [src/commands/collection/import.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/collection/import.ts)_
+_See code: [src/commands/collection/import.ts](src/commands/collection/import.ts)_
 
 ## `kourou config:diff FIRST SECOND`
 
@@ -337,7 +337,7 @@ EXAMPLE
   kourou config:diff config/local/kuzzlerc config/production/kuzzlerc
 ```
 
-_See code: [src/commands/config/diff.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/config/diff.ts)_
+_See code: [src/commands/config/diff.ts](src/commands/config/diff.ts)_
 
 ## `kourou document:create INDEX COLLECTION`
 
@@ -369,7 +369,7 @@ EXAMPLES
   kourou document:create iot sensors < document.json
 ```
 
-_See code: [src/commands/document/create.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/document/create.ts)_
+_See code: [src/commands/document/create.ts](src/commands/document/create.ts)_
 
 ## `kourou document:get INDEX COLLECTION ID`
 
@@ -395,7 +395,7 @@ OPTIONS
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 ```
 
-_See code: [src/commands/document/get.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/document/get.ts)_
+_See code: [src/commands/document/get.ts](src/commands/document/get.ts)_
 
 ## `kourou document:search INDEX COLLECTION`
 
@@ -430,7 +430,7 @@ EXAMPLES
   kourou document:search iot sensors --editor
 ```
 
-_See code: [src/commands/document/search.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/document/search.ts)_
+_See code: [src/commands/document/search.ts](src/commands/document/search.ts)_
 
 ## `kourou es:get INDEX ID`
 
@@ -450,7 +450,7 @@ OPTIONS
   --help           show CLI help
 ```
 
-_See code: [src/commands/es/get.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/es/get.ts)_
+_See code: [src/commands/es/get.ts](src/commands/es/get.ts)_
 
 ## `kourou es:insert INDEX`
 
@@ -471,7 +471,7 @@ OPTIONS
   --id=id          Document ID
 ```
 
-_See code: [src/commands/es/insert.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/es/insert.ts)_
+_See code: [src/commands/es/insert.ts](src/commands/es/insert.ts)_
 
 ## `kourou es:list-index`
 
@@ -488,7 +488,7 @@ OPTIONS
   --help           show CLI help
 ```
 
-_See code: [src/commands/es/list-index.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/es/list-index.ts)_
+_See code: [src/commands/es/list-index.ts](src/commands/es/list-index.ts)_
 
 ## `kourou file:decrypt FILE`
 
@@ -511,7 +511,7 @@ EXAMPLES
   kourou file:decrypt books/cryptonomicon.txt.enc -o books/cryptonomicon.txt --vault-key <vault-key>
 ```
 
-_See code: [src/commands/file/decrypt.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/file/decrypt.ts)_
+_See code: [src/commands/file/decrypt.ts](src/commands/file/decrypt.ts)_
 
 ## `kourou file:encrypt FILE`
 
@@ -534,7 +534,7 @@ EXAMPLES
   kourou file:encrypt books/cryptonomicon.txt -o books/cryptonomicon.txt.enc --vault-key <vault-key>
 ```
 
-_See code: [src/commands/file/encrypt.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/file/encrypt.ts)_
+_See code: [src/commands/file/encrypt.ts](src/commands/file/encrypt.ts)_
 
 ## `kourou file:test FILE`
 
@@ -554,7 +554,7 @@ EXAMPLE
   kourou file:test books/cryptonomicon.txt.enc --vault-key <vault-key>
 ```
 
-_See code: [src/commands/file/test.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/file/test.ts)_
+_See code: [src/commands/file/test.ts](src/commands/file/test.ts)_
 
 ## `kourou help [COMMAND]`
 
@@ -597,7 +597,7 @@ OPTIONS
   --username=username      [default: anonymous] Kuzzle username (local strategy)
 ```
 
-_See code: [src/commands/import.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/import.ts)_
+_See code: [src/commands/import.ts](src/commands/import.ts)_
 
 ## `kourou index:export INDEX`
 
@@ -623,7 +623,7 @@ OPTIONS
   --username=username      [default: anonymous] Kuzzle username (local strategy)
 ```
 
-_See code: [src/commands/index/export.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/index/export.ts)_
+_See code: [src/commands/index/export.ts](src/commands/index/export.ts)_
 
 ## `kourou index:import PATH`
 
@@ -654,7 +654,7 @@ EXAMPLES
   kourou index:import ./dump/iot-data --index iot-data-production --no-mappings
 ```
 
-_See code: [src/commands/index/import.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/index/import.ts)_
+_See code: [src/commands/index/import.ts](src/commands/index/import.ts)_
 
 ## `kourou instance:logs`
 
@@ -669,7 +669,7 @@ OPTIONS
   -i, --instance=instance  Kuzzle instance name
 ```
 
-_See code: [src/commands/instance/logs.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/instance/logs.ts)_
+_See code: [src/commands/instance/logs.ts](src/commands/instance/logs.ts)_
 
 ## `kourou instance:spawn`
 
@@ -685,7 +685,7 @@ OPTIONS
   --help                 show CLI help
 ```
 
-_See code: [src/commands/instance/spawn.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/instance/spawn.ts)_
+_See code: [src/commands/instance/spawn.ts](src/commands/instance/spawn.ts)_
 
 ## `kourou profile:export`
 
@@ -707,7 +707,7 @@ OPTIONS
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 ```
 
-_See code: [src/commands/profile/export.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/profile/export.ts)_
+_See code: [src/commands/profile/export.ts](src/commands/profile/export.ts)_
 
 ## `kourou profile:import PATH`
 
@@ -731,7 +731,7 @@ OPTIONS
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 ```
 
-_See code: [src/commands/profile/import.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/profile/import.ts)_
+_See code: [src/commands/profile/import.ts](src/commands/profile/import.ts)_
 
 ## `kourou role:export`
 
@@ -753,7 +753,7 @@ OPTIONS
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 ```
 
-_See code: [src/commands/role/export.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/role/export.ts)_
+_See code: [src/commands/role/export.ts](src/commands/role/export.ts)_
 
 ## `kourou role:import PATH`
 
@@ -778,7 +778,7 @@ OPTIONS
   --username=username   [default: anonymous] Kuzzle username (local strategy)
 ```
 
-_See code: [src/commands/role/import.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/role/import.ts)_
+_See code: [src/commands/role/import.ts](src/commands/role/import.ts)_
 
 ## `kourou sdk:execute`
 
@@ -832,7 +832,7 @@ DESCRIPTION
        - kourou sdk:execute --code 'return await sdk.server.now()' --editor
 ```
 
-_See code: [src/commands/sdk/execute.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/sdk/execute.ts)_
+_See code: [src/commands/sdk/execute.ts](src/commands/sdk/execute.ts)_
 
 ## `kourou sdk:query CONTROLLER:ACTION`
 
@@ -902,7 +902,7 @@ DESCRIPTION
        - kourou sdk:query server:now --display 'result.now'
 ```
 
-_See code: [src/commands/sdk/query.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/sdk/query.ts)_
+_See code: [src/commands/sdk/query.ts](src/commands/sdk/query.ts)_
 
 ## `kourou subscribe INDEX COLLECTION`
 
@@ -954,7 +954,7 @@ EXAMPLES
   kourou subscribe iot-data sensors --display result._source.temperature
 ```
 
-_See code: [src/commands/subscribe.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/subscribe.ts)_
+_See code: [src/commands/subscribe.ts](src/commands/subscribe.ts)_
 
 ## `kourou user:export`
 
@@ -978,7 +978,7 @@ OPTIONS
   --username=username      [default: anonymous] Kuzzle username (local strategy)
 ```
 
-_See code: [src/commands/user/export.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/user/export.ts)_
+_See code: [src/commands/user/export.ts](src/commands/user/export.ts)_
 
 ## `kourou user:import PATH`
 
@@ -1002,7 +1002,7 @@ OPTIONS
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 ```
 
-_See code: [src/commands/user/import.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/user/import.ts)_
+_See code: [src/commands/user/import.ts](src/commands/user/import.ts)_
 
 ## `kourou vault:add SECRETS-FILE KEY VALUE`
 
@@ -1033,7 +1033,7 @@ EXAMPLE
   kourou vault:add config/secrets.enc.json aws.s3.keyId b61e267676660c314b006b06 --vault-key <vault-key>
 ```
 
-_See code: [src/commands/vault/add.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/vault/add.ts)_
+_See code: [src/commands/vault/add.ts](src/commands/vault/add.ts)_
 
 ## `kourou vault:decrypt FILE`
 
@@ -1063,7 +1063,7 @@ EXAMPLES
   kourou vault:decrypt config/secrets.enc.json -o config/secrets.json --vault-key <vault-key>
 ```
 
-_See code: [src/commands/vault/decrypt.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/vault/decrypt.ts)_
+_See code: [src/commands/vault/decrypt.ts](src/commands/vault/decrypt.ts)_
 
 ## `kourou vault:encrypt FILE`
 
@@ -1104,7 +1104,7 @@ EXAMPLES
   kourou vault:encrypt config/secrets.json -o config/secrets_prod.enc.json --vault-key <vault-key>
 ```
 
-_See code: [src/commands/vault/encrypt.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/vault/encrypt.ts)_
+_See code: [src/commands/vault/encrypt.ts](src/commands/vault/encrypt.ts)_
 
 ## `kourou vault:show SECRETS-FILE [KEY]`
 
@@ -1135,7 +1135,7 @@ EXAMPLES
   kourou vault:show config/secrets.enc.json aws.s3.secretKey --vault-key <vault-key>
 ```
 
-_See code: [src/commands/vault/show.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/vault/show.ts)_
+_See code: [src/commands/vault/show.ts](src/commands/vault/show.ts)_
 
 ## `kourou vault:test SECRETS-FILE`
 
@@ -1160,7 +1160,7 @@ EXAMPLE
   kourou vault:test config/secrets.enc.json --vault-key <vault-key>
 ```
 
-_See code: [src/commands/vault/test.ts](https://github.com/kuzzleio/kourou/blob/v0.13.0/src/commands/vault/test.ts)_
+_See code: [src/commands/vault/test.ts](src/commands/vault/test.ts)_
 <!-- commandsstop -->
 
 # Where does this weird name comes from?

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "plugins": [
       "@oclif/plugin-help"
     ],
+    "repositoryPrefix": "<%- commandPath %>",
     "topics": {
       "api-key": {
         "description": "manage API keys"


### PR DESCRIPTION
## What does this PR do?
Updates all _readme_ file links to be relative instead of absolute by using oclif's **[repositoryPrefix](https://github.com/oclif/dev-cli/blob/v1.22.2/src/commands/readme.ts#L170)**

### How should this be manually tested?

1. Checkout to `fix/readme-links` branch
2. Click on any `'see code'` command link.
