### PR TITLE
Fix app:start-services

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ npm install -g kourou
 $ kourou COMMAND
 running command...
 $ kourou (-v|--version|version)
-kourou/0.15.0 linux-x64 node-v12.16.3
+kourou/0.15.1 linux-x64 node-v12.16.3
 $ kourou --help [COMMAND]
 USAGE
   $ kourou COMMAND

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kourou",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kourou",
   "description": "The CLI that helps you manage your Kuzzle instances",
-  "version": "0.15.0",
+  "version": "0.15.1",
   "author": "The Kuzzle Team <support@kuzzle.io>",
   "bin": {
     "kourou": "./bin/run"

--- a/src/commands/app/start-services.ts
+++ b/src/commands/app/start-services.ts
@@ -64,7 +64,7 @@ export default class AppStartServices extends Kommand {
     try {
       await execute('docker-compose', '-f', docoFilename, 'up', '-d')
 
-      this.logOk(`Elasticsearch and Redis are booting in the background right now.`)
+      this.logOk('Elasticsearch and Redis are booting in the background right now.')
       this.log(chalk.grey('\nTo watch the logs, run'))
       this.log(chalk.grey(`  docker-compose -f ${docoFilename} logs -f\n`))
       this.log('  Elasticsearch port: 9200')


### PR DESCRIPTION
## What does this PR do?

The command `app:start-services` was using `spawn` instead of `execute` and the Docker Compose command execution was not waited before the CLI exit.