### PR TITLE
Redis list keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,9 +131,9 @@ Then any argument will be passed as-is to the `sdk:query` method.
 * [`kourou collection:import PATH`](#kourou-collectionimport-path)
 * [`kourou config:diff FIRST SECOND`](#kourou-configdiff-first-second)
 * [`kourou document:search INDEX COLLECTION [QUERY]`](#kourou-documentsearch-index-collection-query)
+* [`kourou es:indices:cat`](#kourou-esindicescat)
 * [`kourou es:indices:get INDEX ID`](#kourou-esindicesget-index-id)
 * [`kourou es:indices:insert INDEX`](#kourou-esindicesinsert-index)
-* [`kourou es:indices:cat`](#kourou-esindicescat)
 * [`kourou file:decrypt FILE`](#kourou-filedecrypt-file)
 * [`kourou file:encrypt FILE`](#kourou-fileencrypt-file)
 * [`kourou file:test FILE`](#kourou-filetest-file)
@@ -148,6 +148,7 @@ Then any argument will be passed as-is to the `sdk:query` method.
 * [`kourou profile:export`](#kourou-profileexport)
 * [`kourou profile:import PATH`](#kourou-profileimport-path)
 * [`kourou realtime:subscribe INDEX COLLECTION [FILTERS]`](#kourou-realtimesubscribe-index-collection-filters)
+* [`kourou redis:list-keys [MATCH]`](#kourou-redislist-keys-match)
 * [`kourou role:export`](#kourou-roleexport)
 * [`kourou role:import PATH`](#kourou-roleimport-path)
 * [`kourou sdk:execute`](#kourou-sdkexecute)
@@ -453,6 +454,23 @@ EXAMPLES
 
 _See code: [src/commands/document/search.ts](src/commands/document/search.ts)_
 
+## `kourou es:indices:cat`
+
+Lists available ES indexes
+
+```
+USAGE
+  $ kourou es:indices:cat
+
+OPTIONS
+  -g, --grep=grep  Match output with pattern
+  -h, --host=host  [default: localhost] Elasticsearch server host
+  -p, --port=port  [default: 9200] Elasticsearch server port
+  --help           show CLI help
+```
+
+_See code: [src/commands/es/indices/cat.ts](src/commands/es/indices/cat.ts)_
+
 ## `kourou es:indices:get INDEX ID`
 
 Gets a document from ES
@@ -493,23 +511,6 @@ OPTIONS
 ```
 
 _See code: [src/commands/es/indices/insert.ts](src/commands/es/indices/insert.ts)_
-
-## `kourou es:indices:cat`
-
-Lists available ES indexes
-
-```
-USAGE
-  $ kourou es:indices:cat
-
-OPTIONS
-  -g, --grep=grep  Match output with pattern
-  -h, --host=host  [default: localhost] Elasticsearch server host
-  -p, --port=port  [default: 9200] Elasticsearch server port
-  --help           show CLI help
-```
-
-_See code: [src/commands/es/indices/cat.ts](src/commands/es/indices/cat.ts)_
 
 ## `kourou file:decrypt FILE`
 
@@ -836,6 +837,38 @@ EXAMPLES
 ```
 
 _See code: [src/commands/realtime/subscribe.ts](src/commands/realtime/subscribe.ts)_
+
+## `kourou redis:list-keys [MATCH]`
+
+Lists keys stored in Redis
+
+```
+USAGE
+  $ kourou redis:list-keys [MATCH]
+
+ARGUMENTS
+  MATCH  [default: *] Match Redis keys with a pattern
+
+OPTIONS
+  --api-key=api-key    Kuzzle user api-key
+  --as=as              Impersonate a user
+  --help               show CLI help
+  --host=host          [default: localhost] Kuzzle server host
+  --max=max            [default: -1] Maximum number of page to retrieve (-1 to retrieve everything)
+  --password=password  Kuzzle user password
+  --port=port          [default: 7512] Kuzzle server port
+  --protocol=protocol  [default: http] Kuzzle protocol (http or ws)
+  --remove             Remove matching keys
+  --size=size          [default: 100] Page size
+  --ssl                Use SSL to connect to Kuzzle
+  --username=username  [default: anonymous] Kuzzle username (local strategy)
+
+EXAMPLES
+  kourou redis:list-keys "*cluster*"
+  kourou redis:list-keys "counters/*" --remove
+```
+
+_See code: [src/commands/redis/list-keys.ts](src/commands/redis/list-keys.ts)_
 
 ## `kourou role:export`
 

--- a/features/Redis.feature
+++ b/features/Redis.feature
@@ -1,0 +1,38 @@
+Feature: Redis commands
+
+  # redis:list-keys ============================================================
+
+  Scenario: List matching keys
+    Given I successfully call the route "ms":"set" with args:
+      | _id  | "trekking-1"        |
+      | body | { "value": "caner"} |
+    And I successfully call the route "ms":"set" with args:
+      | _id  | "trekking-2"        |
+      | body | { "value": "burak"} |
+    And I successfully call the route "ms":"set" with args:
+      | _id  | "hiking-1"          |
+      | body | { "value": "ozgur"} |
+    When I run the command "redis:list-keys" with:
+      | arg | trekking-* |
+    Then I should match stdout with "caner"
+    And I should match stdout with "burak"
+    And I should not match stdout with "ozgur"
+
+  Scenario: List and delete matching keys
+    Given I successfully call the route "ms":"set" with args:
+      | _id  | "trekking-1"        |
+      | body | { "value": "caner"} |
+    And I successfully call the route "ms":"set" with args:
+      | _id  | "trekking-2"        |
+      | body | { "value": "burak"} |
+    And I successfully call the route "ms":"set" with args:
+      | _id  | "hiking-1"          |
+      | body | { "value": "ozgur"} |
+    And I run the command "redis:list-keys" with:
+      | arg  | trekking-* |
+      | flag | --remove   |
+    When I run the command "redis:list-keys" with:
+      | arg | * |
+    Then I should not match stdout with "caner"
+    And I should not match stdout with "burak"
+    And I should match stdout with "ozgur"

--- a/src/commands/redis/list-keys.ts
+++ b/src/commands/redis/list-keys.ts
@@ -46,7 +46,7 @@ export default class RedisListKeys extends Kommand {
     let pages = 0
 
     do {
-      const result = await this.sdk.ms.scan(cursor, { count, match });
+      const result = await this.sdk.ms.scan(cursor, { count, match })
 
       cursor = result.cursor
 
@@ -59,7 +59,7 @@ export default class RedisListKeys extends Kommand {
       process.stdout.write('\r')
 
       if (maxPages !== -1 && pages >= maxPages) {
-        break;
+        break
       }
     } while (cursor !== '0')
 
@@ -73,10 +73,10 @@ export default class RedisListKeys extends Kommand {
 
     if (this.flags.remove) {
       await this.sdk.ms.del(keys)
-      this.logOk(`${keys.length} keys deleted`);
+      this.logOk(`${keys.length} keys deleted`)
     }
     else {
-      this.logOk(`${keys.length} keys retrieved`);
+      this.logOk(`${keys.length} keys retrieved`)
     }
   }
 }

--- a/src/commands/redis/list-keys.ts
+++ b/src/commands/redis/list-keys.ts
@@ -1,0 +1,78 @@
+import { flags } from '@oclif/command'
+
+import { Kommand } from '../../common'
+import { kuzzleFlags } from '../../support/kuzzle'
+
+export default class RedisListKeys extends Kommand {
+  static description = 'Lists keys stored in Redis'
+
+  static flags = {
+    help: flags.help(),
+    remove: flags.boolean({
+      description: 'Remove matching keys',
+      default: false
+    }),
+    size: flags.string({
+      description: 'Page size',
+      default: '100'
+    }),
+    max: flags.string({
+      description: 'Maximum number of page to retrieve (-1 to retrieve everything)',
+      default: '-1'
+    }),
+    ...kuzzleFlags
+  }
+
+  static args = [
+    { name: 'match', description: 'Match Redis keys with a pattern', default: '*' },
+  ]
+
+  static readStdin = true
+
+  async runSafe() {
+    const match = this.args.match
+    const count = parseInt(this.flags.size, 10)
+    const maxPages = parseInt(this.flags.max, 10)
+
+    this.logInfo(`Start searching for keys matching "${match}...`)
+
+    let keys = []
+    let cursor = '0'
+    let pages = 0
+
+    do {
+      const result = await this.sdk.ms.scan(cursor, { count, match });
+
+      cursor = result.cursor
+
+      for (const key of result.values) {
+        keys.push(key)
+      }
+
+      pages++
+      process.stdout.write(`Iterate on page ${pages}. ${keys.length} keys found so far.`)
+      process.stdout.write('\r')
+
+      if (maxPages !== -1 && pages >= maxPages) {
+        break;
+      }
+    } while (cursor !== '0')
+
+    keys = keys.sort()
+
+    const values = await this.sdk.ms.mget(keys)
+
+    for (let i = 0; i < keys.length; i++) {
+      this.log(`"${keys[i]}" = ${values[i]}`)
+    }
+
+    if (this.flags.remove) {
+      await this.sdk.ms.del(keys)
+      this.logOk(`${keys.length} keys deleted`);
+    }
+    else {
+      this.logOk(`${keys.length} keys retrieved`);
+    }
+  }
+}
+

--- a/src/commands/redis/list-keys.ts
+++ b/src/commands/redis/list-keys.ts
@@ -27,6 +27,11 @@ export default class RedisListKeys extends Kommand {
     { name: 'match', description: 'Match Redis keys with a pattern', default: '*' },
   ]
 
+  static examples = [
+    'kourou redis:list-keys "*cluster*"',
+    'kourou redis:list-keys "counters/*" --remove',
+  ]
+
   static readStdin = true
 
   async runSafe() {

--- a/src/support/kuzzle.ts
+++ b/src/support/kuzzle.ts
@@ -201,4 +201,8 @@ export class KuzzleSDK {
   get realtime() {
     return this.sdk.realtime
   }
+
+  get ms() {
+    return this.sdk.ms
+  }
 }


### PR DESCRIPTION
## What does this PR do?

Adds a command to list Redis keys and associated values.

The command can take a matching pattern and can also remove matching keys

<summary><details>Example</details>

```
$ kourou redis:list-keys "counters/*"             
 
 🚀 Kourou - Lists keys stored in Redis
 
 [ℹ] Connecting to https://localhost ...
 [ℹ] Start searching for keys matching "counters/*...
 "counters/customer-worksite-foobar/NoMMU3MB0jrqxKGVE-2K/area/94PmUXMB0jrqxKGVPNUG" = Vestiaire 1
 "counters/customer-worksite-foobar/NoMMU3MB0jrqxKGVE-2K/area/Z4PrUXMB0jrqxKGVEtbr" = Bureau CdT
 "counters/customer-worksite-foobar/NoMMU3MB0jrqxKGVE-2K/value/Vestiaire 5" = 0
 "counters/customer-worksite-foobar/NoMMU3MB0jrqxKGVE-2K/value/Vestiaire 6" = 0
 "counters/customer-worksite-foobar/lIMSU3MB0jrqxKGVse1p/value/Bureau CdT" = 1
 "counters/customer-worksite-foobar/lIMSU3MB0jrqxKGVse1p/value/Vestiaire 2" = 0
 "counters/customer-worksite-foobar/lIMSU3MB0jrqxKGVse1p/value/Vestiaire 3" = 0
 "counters/customer-worksite-foobar/lIMSU3MB0jrqxKGVse1p/value/Vestiaire 4" = 0
 "counters/customer-worksite-foobar/lIMSU3MB0jrqxKGVse1p/value/Vestiaire 5" = 0
 "counters/customer-worksite-foobar/lIMSU3MB0jrqxKGVse1p/value/Vestiaire 6" = 0
 [...]
 [✔] 55 keys retrieved
```

</summary>