### PR TITLE
Add Quine example

### DIFF
--- a/README.md
+++ b/README.md
@@ -939,6 +939,7 @@ OPTIONS
   --keep-alive         Keep the connection running (websocket only)
   --password=password  Kuzzle user password
   --port=port          [default: 7512] Kuzzle server port
+  --print-raw          Print only the script result to stdout
   --protocol=protocol  [default: ws] Kuzzle protocol (http or ws)
   --ssl                Use SSL to connect to Kuzzle
   --username=username  [default: anonymous] Kuzzle username (local strategy)
@@ -1365,13 +1366,13 @@ We liked the idea that this CLI is like a launchpad for the Kuzzle rocket. The p
 [Quine](https://en.wikipedia.org/wiki/Quine_(computing)) are programs able to print their own source code.
 
 ```bash
-$ kourou sdk:execute --code '(
+$ kourou-dev sdk:execute --print-raw --code '(
   function quine() {
     const sq = String.fromCharCode(39);
     const lp = String.fromCharCode(40);
     const rp = String.fromCharCode(41);
 
-    console.log("kourou sdk:execute --code " + sq + lp + quine.toString() + rp + lp + rp + ";" + sq)
+    console.log("kourou-dev sdk:execute --print-raw --code " + sq + lp + quine.toString() + rp + lp + rp + ";" + sq)
   }
 )()'
 ```

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The CLI that helps you manage your Kuzzle instances.
 * [Usage](#usage)
 * [Commands](#commands)
 * [Where does this weird name come from?](#where-does-this-weird-name-come-from)
+* [Have fun with quine](#have-fun-with-quine)
 <!-- tocstop -->
 
 :warning: This project is currently in beta and breaking changes may occur until the 1.0.0
@@ -1358,3 +1359,19 @@ _See code: [src/commands/vault/test.ts](src/commands/vault/test.ts)_
 # Where does this weird name come from?
 
 We liked the idea that this CLI is like a launchpad for the Kuzzle rocket. The place where you launch and pilot your Kuzzle instance. The place where the European Space Agency launches their rockets is in the country near the city of [Kourou](https://www.wikiwand.com/en/Kourou), in French Guiana, so we liked the idea that the Kuzzle rockets would take off from there.
+
+# Have fun with quine
+
+[Quine](https://en.wikipedia.org/wiki/Quine_(computing)) are programs able to print their own source code.
+
+```bash
+$ kourou sdk:execute --code '(
+  function quine() {
+    const sq = String.fromCharCode(39);
+    const lp = String.fromCharCode(40);
+    const rp = String.fromCharCode(41);
+
+    console.log("kourou sdk:execute --code " + sq + lp + quine.toString() + rp + lp + rp + ";" + sq)
+  }
+)()'
+```

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The CLI that helps you manage your Kuzzle instances.
 * [Usage](#usage)
 * [Commands](#commands)
 * [Where does this weird name come from?](#where-does-this-weird-name-come-from)
-* [Have fun with quine](#have-fun-with-quine)
+* [Have fun with a quine](#have-fun-with-a-quine)
 <!-- tocstop -->
 
 :warning: This project is currently in beta and breaking changes may occur until the 1.0.0
@@ -1361,7 +1361,7 @@ _See code: [src/commands/vault/test.ts](src/commands/vault/test.ts)_
 
 We liked the idea that this CLI is like a launchpad for the Kuzzle rocket. The place where you launch and pilot your Kuzzle instance. The place where the European Space Agency launches their rockets is in the country near the city of [Kourou](https://www.wikiwand.com/en/Kourou), in French Guiana, so we liked the idea that the Kuzzle rockets would take off from there.
 
-# Have fun with quine
+# Have fun with a quine
 
 [Quine](https://en.wikipedia.org/wiki/Quine_(computing)) are programs able to print their own source code.
 

--- a/src/commands/sdk/execute.ts
+++ b/src/commands/sdk/execute.ts
@@ -123,6 +123,7 @@ ${variables}
       this.logOk('Successfully executed SDK code')
 
       if (result !== undefined) {
+        // eslint-disable-next-line no-console
         console.log(JSON.stringify(result, null, 2))
       }
     }

--- a/src/commands/sdk/execute.ts
+++ b/src/commands/sdk/execute.ts
@@ -52,6 +52,9 @@ Other
     'keep-alive': flags.boolean({
       description: 'Keep the connection running (websocket only)'
     }),
+    'print-raw': flags.boolean({
+      description: 'Print only the script result to stdout'
+    }),
     ...kuzzleFlags,
   };
 
@@ -120,7 +123,7 @@ ${variables}
       this.logOk('Successfully executed SDK code')
 
       if (result !== undefined) {
-        this.log(JSON.stringify(result, null, 2))
+        console.log(JSON.stringify(result, null, 2))
       }
     }
 

--- a/src/common.ts
+++ b/src/common.ts
@@ -37,29 +37,46 @@ export abstract class Kommand extends Command {
   }
 
   public log(message?: string): void {
+    if (this.flags['print-raw']) {
+      return;
+    }
+
     super.log(` ${message}`)
   }
 
   public logOk(message: string): void {
+    if (this.flags['print-raw']) {
+      return;
+    }
+
     this.log(chalk.green(`[✔] ${message}`))
   }
 
   public logInfo(message: string): void {
+    if (this.flags['print-raw']) {
+      return;
+    }
+
     this.log(chalk.yellow(`[ℹ] ${message}`))
   }
 
   public logKo(message?: string): void {
+    if (this.flags['print-raw']) {
+      return;
+    }
+
     this.exitCode = 1
     this.log(chalk.red(`[X] ${message}`))
   }
 
   async run() {
-    this.printCommand()
     const kommand = (this.constructor as unknown) as any
 
     const result = this.parse(kommand)
     this.args = result.args
     this.flags = result.flags
+
+    this.printCommand()
 
     if (kommand.readStdin) {
       this.stdin = this.fromStdin()

--- a/src/common.ts
+++ b/src/common.ts
@@ -38,7 +38,7 @@ export abstract class Kommand extends Command {
 
   public log(message?: string): void {
     if (this.flags['print-raw']) {
-      return;
+      return
     }
 
     super.log(` ${message}`)
@@ -46,7 +46,7 @@ export abstract class Kommand extends Command {
 
   public logOk(message: string): void {
     if (this.flags['print-raw']) {
-      return;
+      return
     }
 
     this.log(chalk.green(`[✔] ${message}`))
@@ -54,7 +54,7 @@ export abstract class Kommand extends Command {
 
   public logInfo(message: string): void {
     if (this.flags['print-raw']) {
-      return;
+      return
     }
 
     this.log(chalk.yellow(`[ℹ] ${message}`))
@@ -62,7 +62,7 @@ export abstract class Kommand extends Command {
 
   public logKo(message?: string): void {
     if (this.flags['print-raw']) {
-      return;
+      return
     }
 
     this.exitCode = 1
@@ -158,6 +158,6 @@ export abstract class Kommand extends Command {
     }
 
     // eslint-disable-next-line no-eval
-    return eval(`var o = ${input}; o`)
+    return eval(`var o = ${input} o`)
   }
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -158,6 +158,6 @@ export abstract class Kommand extends Command {
     }
 
     // eslint-disable-next-line no-eval
-    return eval(`var o = ${input} o`)
+    return eval(`var o = ${input}; o`)
   }
 }


### PR DESCRIPTION
## What does this PR do?

Adds a quine example in the README

```
$ kourou-dev sdk:execute --print-raw --code '(
  function quine() {
    const sq = String.fromCharCode(39);
    const lp = String.fromCharCode(40);
    const rp = String.fromCharCode(41);

    console.log("kourou-dev sdk:execute --print-raw --code " + sq + lp + quine.toString() + rp + lp + rp + ";" + sq)
  }
)()' > result.txt

$ cat result.txt 
kourou-dev sdk:execute --print-raw --code '(function quine() {
    const sq = String.fromCharCode(39);
    const lp = String.fromCharCode(40);
    const rp = String.fromCharCode(41);

    console.log("kourou-dev sdk:execute --print-raw --code " + sq + lp + quine.toString() + rp + lp + rp + ";" + sq)
  })();'
```

### Other Changes

 - add the `print-raw` option to print only the script output