### PR TITLE
Add an option to export data in a format compatible with Kuzzle fixtures

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,6 +353,7 @@ OPTIONS
   --api-key=api-key        Kuzzle user api-key
   --as=as                  Impersonate a user
   --batch-size=batch-size  [default: 2000] Maximum batch size (see limits.documentsFetchCount config)
+  --format=format          JSONL or RAW - RAW will export in Kuzzle format usable for fixtures
   --editor                 Open an editor (EDITOR env variable) to edit the query before sending
   --help                   show CLI help
   --host=host              [default: localhost] Kuzzle server host
@@ -721,6 +722,7 @@ OPTIONS
   --api-key=api-key        Kuzzle user api-key
   --as=as                  Impersonate a user
   --batch-size=batch-size  [default: 2000] Maximum batch size (see limits.documentsFetchCount config)
+  --format=format          JSONL or RAW - RAW will export in Kuzzle format usable for fixtures
   --help                   show CLI help
   --host=host              [default: localhost] Kuzzle server host
   --password=password      Kuzzle user password

--- a/README.md
+++ b/README.md
@@ -357,7 +357,7 @@ OPTIONS
   --editor                 Open an editor (EDITOR env variable) to edit the query before sending
 
   --format=format          [default: JSONL] "jsonl or kuzzle - kuzzle will export in Kuzzle format usable for internal
-                           fixtures and jsonl will be usable to re import those data whith kourou
+                           fixtures and jsonl allows to import that data back with kourou
 
   --help                   show CLI help
 
@@ -736,7 +736,7 @@ OPTIONS
   --batch-size=batch-size  [default: 2000] Maximum batch size (see limits.documentsFetchCount config)
 
   --format=format          [default: jsonl] "jsonl or kuzzle - kuzzle will export in Kuzzle format usable for internal
-                           fixtures and jsonl will be usable to re import those data whith kourou
+                           fixtures and jsonl allows to import that data back with kourou
 
   --help                   show CLI help
 

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ OPTIONS
   --api-key=api-key        Kuzzle user api-key
   --as=as                  Impersonate a user
   --batch-size=batch-size  [default: 2000] Maximum batch size (see limits.documentsFetchCount config)
-  --format=format          JSONL or kuzzle - kuzzle will export in Kuzzle format usable for fixtures
+  --format=format          jsonl or kuzzle - kuzzle will export in Kuzzle format usable for internal fixtures and jsonl will be usable to re import those data whith kourou
   --editor                 Open an editor (EDITOR env variable) to edit the query before sending
   --help                   show CLI help
   --host=host              [default: localhost] Kuzzle server host
@@ -722,7 +722,7 @@ OPTIONS
   --api-key=api-key        Kuzzle user api-key
   --as=as                  Impersonate a user
   --batch-size=batch-size  [default: 2000] Maximum batch size (see limits.documentsFetchCount config)
-  --format=format          JSONL or kuzzle - kuzzle will export in Kuzzle format usable for fixtures
+  --format=format          jsonl or kuzzle - kuzzle will export in Kuzzle format usable for internal fixtures and jsonl will be usable to re import those data whith kourou
   --help                   show CLI help
   --host=host              [default: localhost] Kuzzle server host
   --password=password      Kuzzle user password

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ npm install -g kourou
 $ kourou COMMAND
 running command...
 $ kourou (-v|--version|version)
-kourou/0.16.0 linux-x64 node-v12.16.3
+kourou/0.16.0 linux-x64 node-v12.14.1
 $ kourou --help [COMMAND]
 USAGE
   $ kourou COMMAND
@@ -353,16 +353,27 @@ OPTIONS
   --api-key=api-key        Kuzzle user api-key
   --as=as                  Impersonate a user
   --batch-size=batch-size  [default: 2000] Maximum batch size (see limits.documentsFetchCount config)
-  --format=format          jsonl or kuzzle - kuzzle will export in Kuzzle format usable for internal fixtures and jsonl will be usable to re import those data whith kourou
   --editor                 Open an editor (EDITOR env variable) to edit the query before sending
+
+  --format=format          [default: JSONL] "jsonl or kuzzle - kuzzle will export in Kuzzle format usable for internal
+                           fixtures and jsonl will be usable to re import those data whith kourou
+
   --help                   show CLI help
+
   --host=host              [default: localhost] Kuzzle server host
+
   --password=password      Kuzzle user password
+
   --path=path              Dump root directory
+
   --port=port              [default: 7512] Kuzzle server port
+
   --protocol=protocol      [default: ws] Kuzzle protocol (http or websocket)
+
   --query=query            [default: {}] Only dump documents matching the query (JS or JSON format)
+
   --ssl                    Use SSL to connect to Kuzzle
+
   --username=username      [default: anonymous] Kuzzle username (local strategy)
 
 EXAMPLES
@@ -709,7 +720,7 @@ _See code: [src/commands/import.ts](src/commands/import.ts)_
 
 ## `kourou index:export INDEX`
 
-Exports an index (JSONL format)
+Exports an index (JSONL or Kuzzle format)
 
 ```
 USAGE
@@ -722,14 +733,24 @@ OPTIONS
   --api-key=api-key        Kuzzle user api-key
   --as=as                  Impersonate a user
   --batch-size=batch-size  [default: 2000] Maximum batch size (see limits.documentsFetchCount config)
-  --format=format          jsonl or kuzzle - kuzzle will export in Kuzzle format usable for internal fixtures and jsonl will be usable to re import those data whith kourou
+
+  --format=format          [default: jsonl] "jsonl or kuzzle - kuzzle will export in Kuzzle format usable for internal
+                           fixtures and jsonl will be usable to re import those data whith kourou
+
   --help                   show CLI help
+
   --host=host              [default: localhost] Kuzzle server host
+
   --password=password      Kuzzle user password
+
   --path=path              Dump root directory
+
   --port=port              [default: 7512] Kuzzle server port
+
   --protocol=protocol      [default: ws] Kuzzle protocol (http or websocket)
+
   --ssl                    Use SSL to connect to Kuzzle
+
   --username=username      [default: anonymous] Kuzzle username (local strategy)
 ```
 
@@ -1083,7 +1104,7 @@ OPTIONS
   --body-editor                Open an editor (EDITOR env variable) to edit the body before sending.
 
   --display=display            [default: result] Path of the property to display from the response (empty string to
-                               display everything)
+                               display the result)
 
   --editor                     Open an editor (EDITOR env variable) to edit the request before sending.
 

--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ OPTIONS
   --api-key=api-key        Kuzzle user api-key
   --as=as                  Impersonate a user
   --batch-size=batch-size  [default: 2000] Maximum batch size (see limits.documentsFetchCount config)
-  --format=format          JSONL or RAW - RAW will export in Kuzzle format usable for fixtures
+  --format=format          JSONL or kuzzle - kuzzle will export in Kuzzle format usable for fixtures
   --editor                 Open an editor (EDITOR env variable) to edit the query before sending
   --help                   show CLI help
   --host=host              [default: localhost] Kuzzle server host
@@ -722,7 +722,7 @@ OPTIONS
   --api-key=api-key        Kuzzle user api-key
   --as=as                  Impersonate a user
   --batch-size=batch-size  [default: 2000] Maximum batch size (see limits.documentsFetchCount config)
-  --format=format          JSONL or RAW - RAW will export in Kuzzle format usable for fixtures
+  --format=format          JSONL or kuzzle - kuzzle will export in Kuzzle format usable for fixtures
   --help                   show CLI help
   --host=host              [default: localhost] Kuzzle server host
   --password=password      Kuzzle user password

--- a/src/commands/collection/export.ts
+++ b/src/commands/collection/export.ts
@@ -26,7 +26,7 @@ export default class CollectionExport extends Kommand {
       description: 'Open an editor (EDITOR env variable) to edit the query before sending'
     }),
     format: flags.string({
-      description: '"jsonl or kuzzle - kuzzle will export in Kuzzle format usable for internal fixtures and jsonl will be usable to re import those data whith kourou',
+      description: '"jsonl or kuzzle - kuzzle will export in Kuzzle format usable for internal fixtures and jsonl allows to import that data back with kourou',
       default: 'JSONL'
     }),
     ...kuzzleFlags,

--- a/src/commands/collection/export.ts
+++ b/src/commands/collection/export.ts
@@ -26,7 +26,7 @@ export default class CollectionExport extends Kommand {
       description: 'Open an editor (EDITOR env variable) to edit the query before sending'
     }),
     format: flags.string({
-      description: 'JSONL or RAW - RAW will export in Kuzzle format',
+      description: 'JSONL or kuzzle - kuzzle will export in Kuzzle format',
       default: 'JSONL'
     }),
     ...kuzzleFlags,

--- a/src/commands/collection/export.ts
+++ b/src/commands/collection/export.ts
@@ -26,7 +26,7 @@ export default class CollectionExport extends Kommand {
       description: 'Open an editor (EDITOR env variable) to edit the query before sending'
     }),
     format: flags.string({
-      description: 'JSONL or kuzzle - kuzzle will export in Kuzzle format',
+      description: '"jsonl" or "kuzzle" - "kuzzle" will export in Kuzzle format',
       default: 'JSONL'
     }),
     ...kuzzleFlags,

--- a/src/commands/collection/export.ts
+++ b/src/commands/collection/export.ts
@@ -25,6 +25,10 @@ export default class CollectionExport extends Kommand {
     editor: flags.boolean({
       description: 'Open an editor (EDITOR env variable) to edit the query before sending'
     }),
+    format: flags.string({
+      description: 'JSONL or RAW - RAW will export in Kuzzle format',
+      default: 'JSONL'
+    }),
     ...kuzzleFlags,
     protocol: flags.string({
       description: 'Kuzzle protocol (http or websocket)',
@@ -64,7 +68,8 @@ export default class CollectionExport extends Kommand {
       this.sdk,
       this.args.index,
       this.args.collection,
-      exportPath)
+      exportPath,
+      this.flags.format)
 
     await dumpCollectionData(
       this.sdk,
@@ -72,7 +77,8 @@ export default class CollectionExport extends Kommand {
       this.args.collection,
       Number(this.flags['batch-size']),
       exportPath,
-      query)
+      query,
+      this.flags.format)
 
     this.logOk(`Collection ${this.args.index}:${this.args.collection} dumped`)
   }

--- a/src/commands/collection/export.ts
+++ b/src/commands/collection/export.ts
@@ -26,7 +26,7 @@ export default class CollectionExport extends Kommand {
       description: 'Open an editor (EDITOR env variable) to edit the query before sending'
     }),
     format: flags.string({
-      description: '"jsonl" or "kuzzle" - "kuzzle" will export in Kuzzle format',
+      description: '"jsonl or kuzzle - kuzzle will export in Kuzzle format usable for internal fixtures and jsonl will be usable to re import those data whith kourou',
       default: 'JSONL'
     }),
     ...kuzzleFlags,

--- a/src/commands/index/export.ts
+++ b/src/commands/index/export.ts
@@ -20,7 +20,7 @@ export default class IndexExport extends Kommand {
       default: '2000'
     }),
     format: flags.string({
-      description: '"jsonl or kuzzle - kuzzle will export in Kuzzle format usable for internal fixtures and jsonl will be usable to re import those data with kourou',
+      description: '"jsonl or kuzzle - kuzzle will export in Kuzzle format usable for internal fixtures and jsonl will be usable to import that data back with kourou',
       default: 'jsonl'
     }),
     ...kuzzleFlags,

--- a/src/commands/index/export.ts
+++ b/src/commands/index/export.ts
@@ -20,7 +20,7 @@ export default class IndexExport extends Kommand {
       default: '2000'
     }),
     format: flags.string({
-      description: '"jsonl" or "kuzzle" - "jsonl" will export in Kourou format and "kuzzle" will export in Kuzzle fixtures format',
+      description: '"jsonl or kuzzle - kuzzle will export in Kuzzle format usable for internal fixtures and jsonl will be usable to re import those data whith kourou',
       default: 'jsonl'
     }),
     ...kuzzleFlags,

--- a/src/commands/index/export.ts
+++ b/src/commands/index/export.ts
@@ -20,7 +20,7 @@ export default class IndexExport extends Kommand {
       default: '2000'
     }),
     format: flags.string({
-      description: '"jsonl or kuzzle - kuzzle will export in Kuzzle format usable for internal fixtures and jsonl will be usable to re import those data whith kourou',
+      description: '"jsonl or kuzzle - kuzzle will export in Kuzzle format usable for internal fixtures and jsonl will be usable to re import those data with kourou',
       default: 'jsonl'
     }),
     ...kuzzleFlags,

--- a/src/commands/index/export.ts
+++ b/src/commands/index/export.ts
@@ -8,7 +8,7 @@ import { kuzzleFlags } from '../../support/kuzzle'
 import { dumpCollectionData, dumpCollectionMappings } from '../../support/dump-collection'
 
 export default class IndexExport extends Kommand {
-  static description = 'Exports an index (JSONL format)'
+  static description = 'Exports an index (JSONL format or RAW Kuzzle format)'
 
   static flags = {
     help: flags.help({}),
@@ -18,6 +18,10 @@ export default class IndexExport extends Kommand {
     'batch-size': flags.string({
       description: 'Maximum batch size (see limits.documentsFetchCount config)',
       default: '2000'
+    }),
+    format: flags.string({
+      description: 'JSONL or RAW - RAW will export in Kuzzle format',
+      default: 'JSONL'
     }),
     ...kuzzleFlags,
     protocol: flags.string({
@@ -48,14 +52,17 @@ export default class IndexExport extends Kommand {
             this.sdk,
             this.args.index,
             collection.name,
-            exportPath)
+            exportPath,
+            this.flags.format)
 
           await dumpCollectionData(
             this.sdk,
             this.args.index,
             collection.name,
             Number(this.flags['batch-size']),
-            exportPath)
+            exportPath,
+            {},
+            this.flags.format)
 
           cli.action.stop()
         }

--- a/src/commands/index/export.ts
+++ b/src/commands/index/export.ts
@@ -8,7 +8,7 @@ import { kuzzleFlags } from '../../support/kuzzle'
 import { dumpCollectionData, dumpCollectionMappings } from '../../support/dump-collection'
 
 export default class IndexExport extends Kommand {
-  static description = 'Exports an index (JSONL format or RAW Kuzzle format)'
+  static description = 'Exports an index (JSONL format or kuzzle Kuzzle format)'
 
   static flags = {
     help: flags.help({}),
@@ -20,7 +20,7 @@ export default class IndexExport extends Kommand {
       default: '2000'
     }),
     format: flags.string({
-      description: 'JSONL or RAW - RAW will export in Kuzzle format',
+      description: 'JSONL or kuzzle - kuzzle will export in Kuzzle format',
       default: 'JSONL'
     }),
     ...kuzzleFlags,

--- a/src/commands/index/export.ts
+++ b/src/commands/index/export.ts
@@ -8,7 +8,7 @@ import { kuzzleFlags } from '../../support/kuzzle'
 import { dumpCollectionData, dumpCollectionMappings } from '../../support/dump-collection'
 
 export default class IndexExport extends Kommand {
-  static description = 'Exports an index (JSONL format or kuzzle Kuzzle format)'
+  static description = 'Exports an index (JSONL or Kuzzle format)'
 
   static flags = {
     help: flags.help({}),
@@ -20,8 +20,8 @@ export default class IndexExport extends Kommand {
       default: '2000'
     }),
     format: flags.string({
-      description: 'JSONL or kuzzle - kuzzle will export in Kuzzle format',
-      default: 'JSONL'
+      description: '"jsonl" or "kuzzle" - "jsonl" will export in Kourou format and "kuzzle" will export in Kuzzle fixtures format',
+      default: 'jsonl'
     }),
     ...kuzzleFlags,
     protocol: flags.string({

--- a/src/support/dump-collection.ts
+++ b/src/support/dump-collection.ts
@@ -6,9 +6,9 @@ import cli from 'cli-ux'
 // tslint:disable-next-line
 const ndjson = require('ndjson')
 
-export async function dumpCollectionData(sdk: any, index: string, collection: string, batchSize: number, destPath: string, query: any = {}, format = 'JSONL') {
+export async function dumpCollectionData(sdk: any, index: string, collection: string, batchSize: number, destPath: string, query: any = {}, format = 'jsonl') {
   const collectionDir = path.join(destPath, collection)
-  const filename = path.join(collectionDir, (format.toUpperCase() === 'JSONL' ? 'documents.jsonl' : 'documents.json'))
+  const filename = path.join(collectionDir, (format.toLowerCase() === 'jsonl ? 'documents.jsonl' : 'documents.json'))
   const writeStream = fs.createWriteStream(filename)
   const waitWrite = new Promise(resolve => writeStream.on('finish', resolve))
   const ndjsonStream = ndjson.serialize()
@@ -36,7 +36,7 @@ export async function dumpCollectionData(sdk: any, index: string, collection: st
 
   fs.mkdirSync(collectionDir, { recursive: true })
 
-  if (format.toUpperCase() === 'JSONL') {
+  if (format.toLowerCase() === 'jsonl') {
     await writeLine({ type: 'collection', index, collection })
   }
 
@@ -87,7 +87,7 @@ export async function dumpCollectionData(sdk: any, index: string, collection: st
   return waitWrite
 }
 
-export async function dumpCollectionMappings(sdk: any, index: string, collection: string, destPath: string, format = 'JSONL') {
+export async function dumpCollectionMappings(sdk: any, index: string, collection: string, destPath: string, format = 'jsonl') {
   const collectionDir = path.join(destPath, collection)
   const filename = path.join(collectionDir, 'mappings.json')
 
@@ -104,5 +104,5 @@ export async function dumpCollectionMappings(sdk: any, index: string, collection
     }
   }
 
-  fs.writeFileSync(filename, JSON.stringify((format.toUpperCase() === 'JSONL' ? dump : mappings), null, 2))
+  fs.writeFileSync(filename, JSON.stringify((format.toLowerCase() === 'jsonl ? dump : mappings), null, 2))
 }

--- a/src/support/dump-collection.ts
+++ b/src/support/dump-collection.ts
@@ -8,7 +8,7 @@ const ndjson = require('ndjson')
 
 export async function dumpCollectionData(sdk: any, index: string, collection: string, batchSize: number, destPath: string, query: any = {}, format = 'jsonl') {
   const collectionDir = path.join(destPath, collection)
-  const filename = path.join(collectionDir, (format.toLowerCase() === 'jsonl ? 'documents.jsonl' : 'documents.json'))
+  const filename = path.join(collectionDir, (format.toLowerCase() === 'jsonl' ? 'documents.jsonl' : 'documents.json'))
   const writeStream = fs.createWriteStream(filename)
   const waitWrite = new Promise(resolve => writeStream.on('finish', resolve))
   const ndjsonStream = ndjson.serialize()
@@ -104,5 +104,5 @@ export async function dumpCollectionMappings(sdk: any, index: string, collection
     }
   }
 
-  fs.writeFileSync(filename, JSON.stringify((format.toLowerCase() === 'jsonl ? dump : mappings), null, 2))
+  fs.writeFileSync(filename, JSON.stringify((format.toLowerCase() === 'jsonl' ? dump : mappings), null, 2))
 }

--- a/src/support/dump-collection.ts
+++ b/src/support/dump-collection.ts
@@ -76,7 +76,7 @@ export async function dumpCollectionData(sdk: any, index: string, collection: st
     }
   } while ((results = await results.next()))
 
-  if (format.toLocaleLowerCase() === 'raw') {
+  if (format.toLocaleLowerCase() === 'kuzzle') {
     await writeLine(rawDocuments)
   }
 


### PR DESCRIPTION
## What does this PR do?

Add option to export in JSON understandable for Kuzzle fixtures.

fix #56 

### How should this be manually tested?

```
kourou index:export my-index --format=raw
kourou collection:export my-index my-collection --format=raw
```