### PR TITLE
Make sure that all dependencies for a scaffolded application are installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ $ npm install -g kourou
 $ kourou COMMAND
 running command...
 $ kourou (-v|--version|version)
-kourou/0.17.1 linux-x64 node-v12.16.2
+kourou/0.17.2 linux-x64 node-v12.16.2
 $ kourou --help [COMMAND]
 USAGE
   $ kourou COMMAND

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "kourou",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kourou",
   "description": "The CLI that helps you manage your Kuzzle instances",
-  "version": "0.17.1",
+  "version": "0.17.2",
   "author": "The Kuzzle Team <support@kuzzle.io>",
   "bin": {
     "kourou": "./bin/run"

--- a/src/commands/app/scaffold.ts
+++ b/src/commands/app/scaffold.ts
@@ -35,7 +35,7 @@ export default class AppScaffold extends Kommand {
 
     const tasks = new Listr([
       {
-        title: `Creating ${chalk.gray(this.args.name + path.sep)} directory`,
+        title: `Creating directory: ${chalk.gray(this.args.name + path.sep)}`,
         task: () => execute('mkdir', this.args.name)
       },
       {
@@ -43,15 +43,15 @@ export default class AppScaffold extends Kommand {
         task: () => this.renderTemplates(templatePath, templatePath)
       },
       {
-        title: 'Installing latest Kuzzle version via NPM and Docker (this can take some time)',
+        title: 'Installing dependencies (this can take some time)',
         task: () =>
-          execute('npm', 'run', 'npm:docker', 'install', 'kuzzle', { cwd: this.args.name })
+          execute('npm', 'run', 'install:docker', { cwd: this.args.name })
       },
     ])
 
     await tasks.run()
 
-    this.logOk(`Scaffolding complete! Use "${chalk.grey('npm run dev:docker')}" to run your application`)
+    this.logOk(`Scaffolding complete! Use "${chalk.grey('cd ' + this.args.name + ' && npm run dev:docker')}" to run your application`)
   }
 
   async renderTemplates(directory: string, templatePath: string) {

--- a/templates/app-scaffold/ts/README.md
+++ b/templates/app-scaffold/ts/README.md
@@ -6,14 +6,18 @@ _An application running with [Kuzzle](https://github.com/kuzzleio/kuzzle)_
 
 ### Installation
 
-Requirement: 
- - Docker
- - Docker-Compose
+The command `kourou app:scaffold` takes care of installing dependencies for you, so you shouldn't need to worry about it.
 
-First you need to install dependencies. You can use the `npm run install:docker` to install dependencies from inside the container.
+However, if for some reason you need to reinstall dependencies (or add new ones), then you can easily do so by running the following command:
+
+`npm run install:docker`
+
+This command installs the dependencies listed in the `package.json` file of this project, inside the docker image. Since some dependencies are written in C or in C++ and compiled, installing in the target docker image ensures that there won't be incompatibility problems if your current system is different from the one used by docker to execute Kuzzle.
 
 ### Run
 
-You can use the `npm run dev:docker` to run the application with it's dependencies.  
+You can use the following command  to run your application in development mode:
 
-The application will be reloaded on code change.
+`npm run dev:docker`
+
+The application will be reloaded whenever the code changes.

--- a/templates/app-scaffold/ts/package.json
+++ b/templates/app-scaffold/ts/package.json
@@ -5,7 +5,7 @@
   "author": "",
   "scripts": {
     "npm:docker": "docker-compose run kuzzle npm",
-    "install:docker": "npm run npm:docker install kuzzle",
+    "install:docker": "npm run npm:docker install",
     "dev:docker": "docker-compose up",
     "dev": "npx nodemon --ext 'js,json,ts' --inspect=0.0.0.0:9229 --exec node -r ts-node/register app.ts",
     "test": "npm run test:lint && npm run test:unit && npm run test:functional",

--- a/templates/app-scaffold/ts/package.json
+++ b/templates/app-scaffold/ts/package.json
@@ -18,7 +18,7 @@
   "main": "app.ts",
   "license": "Apache-2.0",
   "dependencies": {
-    "kuzzle": "^2.7.0"
+    "kuzzle": ">=2 <3"
   },
   "devDependencies": {
     "@types/node": "^14.14.7",


### PR DESCRIPTION
# Description

The `app:scaffold` command only installs the `kuzzle` dependency, namely, effectively ignoring the dependencies listed in the `package.json` file.

This prevents the `dev:docker` command to run correctly since the `ts-node` module is not installed when the application is scaffolded.

This PR fixes that.

# Other changes

More accurate README.md file for the scaffolded application