### PR TITLE
Add lang option support to document:search

### DIFF
--- a/features/Document.feature
+++ b/features/Document.feature
@@ -11,8 +11,8 @@ Feature: Document Management
       | body | { "name": "Sebastien", "city": "Cassis" } |
     And I refresh the collection
     When I run the command "document:search" with:
-      | arg | nyc-open-data                |
-      | arg | yellow-taxi                  |
-      | arg | { term: { city: "Saigon" } } |
+      | arg | nyc-open-data                  |
+      | arg | yellow-taxi                    |
+      | arg | { equals: { city: "Saigon" } } |
     Then I should match stdout with "Adrien"
     And I should not match stdout with "Sebastien"

--- a/src/commands/document/search.ts
+++ b/src/commands/document/search.ts
@@ -25,6 +25,10 @@ export default class DocumentSearch extends Kommand {
     scroll: flags.string({
       description: 'Optional scroll TTL'
     }),
+    lang: flags.string({
+      description: 'Specify the query language to use',
+      default: 'koncorde'
+    }),
     editor: flags.boolean({
       description: 'Open an editor (EDITOR env variable) to edit the request before sending'
     }),
@@ -35,7 +39,7 @@ export default class DocumentSearch extends Kommand {
   static args = [
     { name: 'index', description: 'Index name', required: true },
     { name: 'collection', description: 'Collection name', required: true },
-    { name: 'query', description: 'Query in JS or JSON format.' },
+    { name: 'query', description: 'Search query in JS or JSON format.' },
   ]
 
   async runSafe() {
@@ -47,6 +51,7 @@ export default class DocumentSearch extends Kommand {
       from: this.flags.from,
       size: this.flags.size,
       scroll: this.flags.scroll,
+      lang: this.flags.lang,
       body: {
         query: this.parseJs(this.args.query || '{}'),
         sort: this.parseJs(this.flags.sort)

--- a/src/commands/document/search.ts
+++ b/src/commands/document/search.ts
@@ -7,7 +7,8 @@ export default class DocumentSearch extends Kommand {
   static description = 'Searches for documents'
 
   static examples = [
-    'kourou document:search iot sensors \'{ term: { name: "corona" } }\'',
+    'kourou document:search iot sensors \'{ equals: { name: "corona" } }\'',
+    'kourou document:search iot sensors \'{ match: { name: "cOrOnna" } }\' -a lang=elasticsearch',
     'kourou document:search iot sensors --editor',
   ]
 


### PR DESCRIPTION
## What does this PR do?

Support `lang` option with document search. 

Also make `koncorde` the default query language.