### PR TITLE
Support SSL for ES commands

### DIFF
--- a/features/Elasticsearch.feature
+++ b/features/Elasticsearch.feature
@@ -33,32 +33,24 @@ Feature: Elasticsearch commands
 
   Scenario: Create a snapshot repository
     When I run the command "es:snapshot:create-repository" with:
-      | arg  | backup         |           |
-      | arg  | /tmp/snapshots |           |
-      | flag | --host         | localhost |
-      | flag | --port         | 9200      |
-      | flag | --compress     |           |
+      | arg  | backup         |  |
+      | arg  | /tmp/snapshots |  |
+      | flag | --compress     |  |
     Then I should match stdout with "Success"
 
   Scenario: Dump ES data to a snapshot into a repository
     When I run the command "es:snapshot:create" with:
-      | arg  | backup        |           |
-      | arg  | test-snapshot |           |
-      | flag | --host        | localhost |
-      | flag | --port        | 9200      |
+      | arg | backup        |  |
+      | arg | test-snapshot |  |
     Then I should match stdout with "Success"
 
   Scenario: List all available snapshot of a repository
     When I run the command "es:snapshot:list" with:
-      | arg  | backup |           |
-      | flag | --host | localhost |
-      | flag | --port | 9200      |
+      | arg | backup |  |
     Then I should match stdout with "test-snapshot"
 
   Scenario: Sucessfully Restore a snapshot into a running ES instance
     When I run the command "es:snapshot:restore" with:
-      | arg  | backup        |           |
-      | arg  | test-snapshot |           |
-      | flag | --host        | localhost |
-      | flag | --port        | 9200      |
+      | arg | backup        |  |
+      | arg | test-snapshot |  |
     Then I should match stdout with "Success"

--- a/src/commands/es/indices/cat.ts
+++ b/src/commands/es/indices/cat.ts
@@ -10,38 +10,35 @@ export default class EsListIndex extends Kommand {
 
   static flags = {
     help: flags.help(),
-    host: flags.string({
-      char: 'h',
-      description: 'Elasticsearch server host',
-      default: process.env.KUZZLE_HOST || 'localhost',
-    }),
-    port: flags.string({
-      char: 'p',
-      description: 'Elasticsearch server port',
-      default: process.env.KUZZLE_PORT || '9200',
+    node: flags.string({
+      char: 'n',
+      description: 'Elasticsearch server URL',
+      default: 'http://localhost:9200',
     }),
     grep: flags.string({
       char: 'g',
       description: 'Match output with pattern',
-    })
+    }),
   }
 
   async runSafe() {
-    // @todo support ssl
-    const node = `http://${this.flags.host}:${this.flags.port}`
+    const esClient = new Client({ node: this.flags.node })
 
-    const esClient = new Client({ node })
+    try {
+      const { body } = await esClient.cat.indices({ format: 'json' })
+      // nice typescript destructuring syntax (:
+      const indexes: string[] = body
+        .map(({ index }: { index: string }) => index)
+        .filter((index: string) => (
+          this.flags.grep ? index.match(new RegExp(this.flags.grep)) : true
+        ))
+        .sort()
 
-    const { body } = await esClient.cat.indices({ format: 'json' })
+      this.log(JSON.stringify(indexes, null, 2))
 
-    // nice typescript destructuring syntax (:
-    const indexes: string[] = body
-      .map(({ index }: { index: string }) => index)
-      .filter((index: string) => (
-        this.flags.grep ? index.match(new RegExp(this.flags.grep)) : true
-      ))
-      .sort()
-
-    this.log(JSON.stringify(indexes, null, 2))
+    }
+    catch (error) {
+      console.log(error)
+    }
   }
 }

--- a/src/commands/es/indices/get.ts
+++ b/src/commands/es/indices/get.ts
@@ -10,15 +10,10 @@ export default class EsGet extends Kommand {
 
   static flags = {
     help: flags.help(),
-    host: flags.string({
-      char: 'h',
-      description: 'Elasticsearch server host',
-      default: process.env.KUZZLE_HOST || 'localhost',
-    }),
-    port: flags.string({
-      char: 'p',
-      description: 'Elasticsearch server port',
-      default: process.env.KUZZLE_PORT || '9200',
+    node: flags.string({
+      char: 'n',
+      description: 'Elasticsearch server URL',
+      default: 'http://localhost:9200',
     }),
   }
 
@@ -28,10 +23,7 @@ export default class EsGet extends Kommand {
   ]
 
   async runSafe() {
-    // @todo support ssl
-    const node = `http://${this.flags.host}:${this.flags.port}`
-
-    const esClient = new Client({ node })
+    const esClient = new Client({ node: this.flags.node })
 
     const esRequest = {
       index: this.args.index,

--- a/src/commands/es/indices/insert.ts
+++ b/src/commands/es/indices/insert.ts
@@ -16,15 +16,10 @@ export default class EsInsert extends Kommand {
     id: flags.string({
       description: 'Document ID'
     }),
-    host: flags.string({
-      char: 'h',
-      description: 'Elasticsearch server host',
-      default: process.env.KUZZLE_HOST || 'localhost',
-    }),
-    port: flags.string({
-      char: 'p',
-      description: 'Elasticsearch server port',
-      default: process.env.KUZZLE_PORT || '9200',
+    node: flags.string({
+      char: 'n',
+      description: 'Elasticsearch server URL',
+      default: 'http://localhost:9200',
     }),
     help: flags.help(),
   }
@@ -34,10 +29,7 @@ export default class EsInsert extends Kommand {
   ]
 
   async runSafe() {
-    // @todo support ssl
-    const node = `http://${this.flags.host}:${this.flags.port}`
-
-    const esClient = new Client({ node })
+    const esClient = new Client({ node: this.flags.node })
 
     const esRequest = {
       index: this.args.index,

--- a/src/commands/es/snapshot/create-repository.ts
+++ b/src/commands/es/snapshot/create-repository.ts
@@ -13,15 +13,10 @@ export default class EsSnapshotsCreateRepository extends Kommand {
       description: 'Compress data when storing them',
       default: false
     }),
-    host: flags.string({
-      char: 'h',
-      description: 'Elasticsearch server host',
-      default: process.env.KUZZLE_HOST || 'localhost',
-    }),
-    port: flags.string({
-      char: 'p',
-      description: 'Elasticsearch server port',
-      default: process.env.KUZZLE_PORT || '9200',
+    node: flags.string({
+      char: 'n',
+      description: 'Elasticsearch server URL',
+      default: 'http://localhost:9200',
     }),
     help: flags.help(),
   }
@@ -32,10 +27,7 @@ export default class EsSnapshotsCreateRepository extends Kommand {
   ]
 
   async runSafe() {
-    // @todo support ssl
-    const node = `http://${this.flags.host}:${this.flags.port}`
-
-    const esClient = new Client({ node })
+    const esClient = new Client({ node: this.flags.node })
 
     const esRequest = {
       repository: this.args.repository,

--- a/src/commands/es/snapshot/create.ts
+++ b/src/commands/es/snapshot/create.ts
@@ -9,15 +9,10 @@ export default class EsSnapshotsCreate extends Kommand {
   static description = 'Create a snapshot repository inside an ES instance'
 
   static flags = {
-    host: flags.string({
-      char: 'h',
-      description: 'Elasticsearch server host',
-      default: process.env.KUZZLE_HOST || 'localhost',
-    }),
-    port: flags.string({
-      char: 'p',
-      description: 'Elasticsearch server port',
-      default: process.env.KUZZLE_PORT || '9200',
+    node: flags.string({
+      char: 'n',
+      description: 'Elasticsearch server URL',
+      default: 'http://localhost:9200',
     }),
     help: flags.help(),
   }
@@ -28,10 +23,7 @@ export default class EsSnapshotsCreate extends Kommand {
   ]
 
   async runSafe() {
-    // @todo support ssl
-    const node = `http://${this.flags.host}:${this.flags.port}`
-
-    const esClient = new Client({ node })
+    const esClient = new Client({ node: this.flags.node })
 
     const esRequest = {
       repository: this.args.repository,

--- a/src/commands/es/snapshot/list.ts
+++ b/src/commands/es/snapshot/list.ts
@@ -9,15 +9,10 @@ export default class EsSnapshotsList extends Kommand {
   static description = 'List all snapshot from a repository acknowledge by an ES instance'
 
   static flags = {
-    host: flags.string({
-      char: 'h',
-      description: 'Elasticsearch server host',
-      default: process.env.KUZZLE_HOST || 'localhost',
-    }),
-    port: flags.string({
-      char: 'p',
-      description: 'Elasticsearch server port',
-      default: process.env.KUZZLE_PORT || '9200',
+    node: flags.string({
+      char: 'n',
+      description: 'Elasticsearch server URL',
+      default: 'http://localhost:9200',
     }),
     help: flags.help(),
   }
@@ -27,10 +22,7 @@ export default class EsSnapshotsList extends Kommand {
   ]
 
   async runSafe() {
-    // @todo support ssl
-    const node = `http://${this.flags.host}:${this.flags.port}`
-
-    const esClient = new Client({ node })
+    const esClient = new Client({ node: this.flags.node })
 
     const esRequest = {
       repository: this.args.repository,

--- a/src/commands/es/snapshot/restore.ts
+++ b/src/commands/es/snapshot/restore.ts
@@ -9,15 +9,10 @@ export default class ESRestore extends Kommand {
   static description = 'Restore a snapshot into an ES instance'
 
   static flags = {
-    host: flags.string({
-      char: 'h',
-      description: 'Elasticsearch server host',
-      default: process.env.KUZZLE_HOST || 'localhost',
-    }),
-    port: flags.string({
-      char: 'p',
-      description: 'Elasticsearch server port',
-      default: process.env.KUZZLE_PORT || '9200',
+    node: flags.string({
+      char: 'n',
+      description: 'Elasticsearch server URL',
+      default: 'http://localhost:9200',
     }),
     help: flags.help(),
   }
@@ -37,10 +32,7 @@ export default class ESRestore extends Kommand {
   }
 
   async runSafe() {
-    // @todo support ssl
-    const node = `http://${this.flags.host}:${this.flags.port}`
-
-    const esClient = new Client({ node })
+    const esClient = new Client({ node: this.flags.node })
 
     const indices = await this.getIndices(esClient)
 


### PR DESCRIPTION
## What does this PR do?

Add SSL support for `es` commands.

The ES URL is now passed directly instead of trying to construct it from `host` and `port`