### PR TITLE
Minikube

### DIFF
--- a/.github/workflows/pull_request.workflow.yml
+++ b/.github/workflows/pull_request.workflow.yml
@@ -83,6 +83,8 @@ jobs:
         run: |
           tar xfz ./kourou-*.tgz
           cp -fr .mocharc.json .nycrc tsconfig.json features test package/
+      - name: Start minikube
+        uses: medyagh/setup-minikube@master
       - uses: ./.github/actions/functional-test
         with:
           test-set: ${{ matrix.test-set }}

--- a/.github/workflows/pull_request.workflow.yml
+++ b/.github/workflows/pull_request.workflow.yml
@@ -83,6 +83,9 @@ jobs:
         run: |
           tar xfz ./kourou-*.tgz
           cp -fr .mocharc.json .nycrc tsconfig.json features test package/
+      - uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 1.0.8
       - name: Start minikube
         uses: medyagh/setup-minikube@master
       - uses: ./.github/actions/functional-test

--- a/.github/workflows/push_dev.workflow.yml
+++ b/.github/workflows/push_dev.workflow.yml
@@ -86,6 +86,9 @@ jobs:
         run: |
           tar xfz ./kourou-*.tgz
           cp -fr .mocharc.json .nycrc tsconfig.json features test package/
+      - uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 1.0.8
       - name: Start minikube
         uses: medyagh/setup-minikube@master
       - uses: ./.github/actions/functional-test

--- a/.github/workflows/push_dev.workflow.yml
+++ b/.github/workflows/push_dev.workflow.yml
@@ -86,6 +86,8 @@ jobs:
         run: |
           tar xfz ./kourou-*.tgz
           cp -fr .mocharc.json .nycrc tsconfig.json features test package/
+      - name: Start minikube
+        uses: medyagh/setup-minikube@master
       - uses: ./.github/actions/functional-test
         with:
           test-set: ${{ matrix.test-set }}

--- a/.github/workflows/push_master.workflow.yml
+++ b/.github/workflows/push_master.workflow.yml
@@ -86,6 +86,9 @@ jobs:
         run: |
           tar xfz ./kourou-*.tgz
           cp -fr .mocharc.json .nycrc tsconfig.json features test package/
+      - uses: hashicorp/setup-terraform@v1
+        with:
+          terraform_version: 1.0.8
       - name: Start minikube
         uses: medyagh/setup-minikube@master
       - uses: ./.github/actions/functional-test

--- a/.github/workflows/push_master.workflow.yml
+++ b/.github/workflows/push_master.workflow.yml
@@ -86,6 +86,8 @@ jobs:
         run: |
           tar xfz ./kourou-*.tgz
           cp -fr .mocharc.json .nycrc tsconfig.json features test package/
+      - name: Start minikube
+        uses: medyagh/setup-minikube@master
       - uses: ./.github/actions/functional-test
         with:
           test-set: ${{ matrix.test-set }}

--- a/src/commands/minikube/start.ts
+++ b/src/commands/minikube/start.ts
@@ -1,0 +1,96 @@
+import { writeFileSync } from 'fs'
+
+import { flags } from '@oclif/command'
+import chalk from 'chalk'
+import Listr from 'listr'
+import emoji from 'node-emoji'
+
+import { Kommand } from '../../common'
+import { execute } from '../../support/execute'
+
+export default class MinikubeStart extends Kommand {
+  static initSdk = false
+
+  public static description = 'Starts Kuzzle kuzzle stack on minikube';
+
+  public static flags = {
+    help: flags.help(),
+    check: flags.boolean({
+      description: 'Check prerequisite before running services',
+      default: false,
+    }),
+  };
+
+  async runSafe() {
+    const docoFilename = '/tmp/kuzzle-services.yml'
+
+    const successfullCheck = this.flags.check ?
+      await this.checkPrerequisites() : true
+
+    if (this.flags.check && successfullCheck) {
+      this.log(`\n${emoji.get('ok_hand')} Prerequisites are ${chalk.green.bold('OK')}!`)
+    } else if (this.flags.check && !successfullCheck) {
+      throw new Error(`${emoji.get('shrug')} Your system doesn't satisfy all the prerequisites`)
+    }
+
+    // clean up
+    await execute('docker-compose', '-f', docoFilename, 'down')
+
+    await execute('docker-compose', '-f', docoFilename, 'up', '-d')
+
+    this.logOk('Elasticsearch and Redis are booting in the background right now.')
+    this.log(chalk.grey('\nTo watch the logs, run'))
+    this.log(chalk.grey(`  docker-compose -f ${docoFilename} logs -f\n`))
+    this.log('  Elasticsearch port: 9200')
+    this.log('  Redis port: 6379')
+  }
+
+  public async checkPrerequisites(): Promise<boolean> {
+    this.log(chalk.grey('Checking prerequisites...'))
+
+    const checks: Listr = new Listr([
+      {
+        title: `Minikube is installed`,
+        task: async () => {
+          const minikubeVersionCommand = await execute('minikube', 'version')
+          const matches = minikubeVersionCommand.stdout.match(/[^0-9.]*([0-9.]*).*/)
+          if (matches === null) {
+            throw new Error(
+              'Unable to read minikube. This is weird.',
+            )
+          }
+          const minikubeVersion = matches.length > 0 ? matches[1] : null
+
+          if (minikubeVersion === null) {
+            throw new Error(
+              'Unable to read minikube version. This is weird.',
+            )
+          }
+        },
+      },
+      {
+        title: `Terraform is installed`,
+        task: async () => {
+          const terraformVersionCommand = await execute('terraform', 'version')
+          const matches = terraformVersionCommand.stdout.match(/[^0-9.]*([0-9.]*).*/)
+
+          if (matches === null) {
+            throw new Error(
+              'Unable to read terraform version. This is weird.',
+            )
+          }
+          const terraformVersion = matches.length > 0 ? matches[1] : null
+
+          if (terraformVersion === null) {
+            throw new Error(
+              'Unable to read terraform version. This is weird.',
+            )
+          }
+        },
+      }
+    ])
+
+    await checks.run()
+    return true
+  }
+}

--- a/src/commands/minikube/stop.ts
+++ b/src/commands/minikube/stop.ts
@@ -1,0 +1,78 @@
+import { flags } from '@oclif/command'
+import chalk from 'chalk'
+import Listr from 'listr'
+import emoji from 'node-emoji'
+
+import { Kommand } from '../../common'
+import { execute } from '../../support/execute'
+
+const MIN_TF_VERSION = '1.0.0'
+
+export default class MinikubeStop extends Kommand {
+  static initSdk = false
+
+  public static description = 'Stop Kuzzle kuzzle stack on minikube';
+
+  public static flags = {
+    help: flags.help(),
+    check: flags.boolean({
+      description: 'Check prerequisite before running services',
+      default: false,
+    }),
+  };
+
+  async runSafe() {
+    const successfullCheck = this.flags.check ?
+      await this.checkPrerequisites() : true
+
+    if (this.flags.check && successfullCheck) {
+      this.log(`\n${emoji.get('ok_hand')} Prerequisites are ${chalk.green.bold('OK')}!`)
+    } else if (this.flags.check && !successfullCheck) {
+      throw new Error(`${emoji.get('shrug')} Your system doesn't satisfy all the prerequisites`)
+    }
+
+    await execute('minikube', 'stop')
+  }
+
+  public async checkPrerequisites(): Promise<boolean> {
+    this.log(chalk.grey('Checking prerequisites...'))
+
+    const checks: Listr = new Listr([
+      {
+        title: `Minikube is installed`,
+        task: async () => {
+          await execute('minikube', 'version')
+        },
+      },
+      {
+        title: `Terraform is installed and at the right version`,
+        task: async () => {
+          const terraformVersionCommand = await execute('terraform', 'version')
+          const matches = terraformVersionCommand.stdout.match(/[^0-9.]*([0-9.]*).*/)
+
+          if (matches === null) {
+            throw new Error(
+              'Unable to read terraform version. This is weird.',
+            )
+          }
+          const terraformVersion = matches.length > 0 ? matches[1] : null
+
+          if (terraformVersion === null) {
+            throw new Error(
+              'Unable to read terraform version. This is weird.',
+            )
+          }
+
+          if (terraformVersion < MIN_TF_VERSION) {
+            throw new Error(
+              `The detected version of Terraform (${terraformVersion}) is not recent enough (${MIN_TF_VERSION})`,
+            )
+          }
+        },
+      }
+    ])
+
+    await checks.run()
+    return true
+  }
+}

--- a/test/commands/app/minikube.test.ts
+++ b/test/commands/app/minikube.test.ts
@@ -14,7 +14,7 @@ xdescribe('minikube:start', () => {
     })
     .it('Spawns Kuzzle v2 stack', async (ctx, done) => {
       await wait(10 * SECOND)
-      expect(ctx.stdout).to.contain('Terraform applied successfuly')
+      expect(ctx.stdout).to.contain('Apply completed')
       done()
     })
 })

--- a/test/commands/app/minikube.test.ts
+++ b/test/commands/app/minikube.test.ts
@@ -1,0 +1,20 @@
+import { expect, test } from '@oclif/test'
+import { execSync } from 'child_process'
+
+const SECOND = 1000
+const wait = (ms: number) => new Promise(resolve => setTimeout(resolve, ms))
+
+xdescribe('minikube:start', () => {
+  test
+    .timeout(50 * SECOND)
+    .stdout({ print: false })
+    .command(['minikube:start'])
+    .finally(() => {
+      execSync('minikube delete')
+    })
+    .it('Spawns Kuzzle v2 stack', async (ctx, done) => {
+      await wait(10 * SECOND)
+      expect(ctx.stdout).to.contain('Terraform applied successfuly')
+      done()
+    })
+})


### PR DESCRIPTION
<!--
  This template is optional.
  It simply serves to provide a guide to allow a better review of pull requests.
-->

<!--
  IMPORTANT
  Don't forget to add the corresponding "changelog:xxx" label to your PR.
  This is part of our release process in order to generate the change log.
-->


## What does this PR do?
<!-- Please fill this section -->

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

This PR add the support of `minikube:start` & `minikube:stop commands`

It allow users to start a minikube cluster with the default kuzzle stack 

* kuzzle `kuzzleio/kuzzle:2`
* elasticsearch
* redis

Helm charts are used in order to work properly.

This PR needs work in order to be fully available.

Kuzzle helm chart need to be publish and Scaffold repository needs to be publicly available.

This PR will be in draft while the work is ending.

### How should this be manually tested?

<!--
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration
-->
  - Step 1 : `npm run build`
  - Step 2 : install minikube and terraform
  - Step 3 :  run `./bin/run minikube:start`
  ...

### Other changes

<!--
  Please describe here all changes not directly linked to the main issue, but made because of it.
  For instance: issues spotted during this PR and fixed on-the-fly, dependencies update, and so on
-->

### Boyscout

<!--
  Describe here minor improvements in the code base and not directly linked to the main changes:
  typos fixes, better/new comments, small code simplification, new debug messages, and so on.
-->
