### PR TITLE
Adding the Open API specification

### DIFF
--- a/doc/swagger/docker-compose.yaml
+++ b/doc/swagger/docker-compose.yaml
@@ -1,0 +1,11 @@
+version: '3.3'
+services:
+  swagger-ui:
+    image: swaggerapi/swagger-ui
+    container_name: swagger-ui
+    ports:
+      - "8001:8080"
+    volumes:
+      - ./swagger:/usr/share/nginx/html/swagger
+    environment:
+      API_URL: swagger/api.yaml

--- a/doc/swagger/swagger/README.md
+++ b/doc/swagger/swagger/README.md
@@ -14,3 +14,5 @@
 
 - [data types](https://swagger.io/docs/specification/data-models/data-types/)
 - [split open api spec into multiple files](https://davidgarcia.dev/posts/how-to-split-open-api-spec-into-multiple-files/)
+- [Describe parameters](https://swagger.io/docs/specification/describing-parameters/)
+- [Inheritance and Polymorphism](https://swagger.io/docs/specification/data-models/inheritance-and-polymorphism/)

--- a/doc/swagger/swagger/README.md
+++ b/doc/swagger/swagger/README.md
@@ -1,0 +1,16 @@
+# Swagger ressources
+
+#### What is Open API / Swagger
+
+- [open api](https://swagger.io/specification/)
+- [swagger ui](https://swagger.io/tools/swagger-ui/)
+
+#### Crate Docker container for Swagger
+
+- [docker container](https://medium.com/wesionary-team/swagger-ui-on-docker-for-testing-rest-apis-5b3d5fcdee7)
+- [docker container2](https://dev.to/katsuya_9/try-using-swagger-ui-m8e)
+
+#### Useful links about Swagger syntax
+
+- [data types](https://swagger.io/docs/specification/data-models/data-types/)
+- [split open api spec into multiple files](https://davidgarcia.dev/posts/how-to-split-open-api-spec-into-multiple-files/)

--- a/doc/swagger/swagger/api.yaml
+++ b/doc/swagger/swagger/api.yaml
@@ -1,0 +1,25 @@
+swagger: "2.0"
+info:
+  description: "This is a sample server Petstore server.  You can find out more about     Swagger at [http://swagger.io](http://swagger.io) or on [irc.freenode.net, #swagger](http://swagger.io/irc/).      For this sample, you can use the api key `special-key` to test the authorization     filters."
+  version: "1.0.0"
+  title: "Swagger Kuzzle"
+  termsOfService: "http://swagger.io/terms/"
+  contact:
+    email: "job@kuzzle.io"
+  license:
+    name: "Apache 2.0"
+    url: "http://www.apache.org/licenses/LICENSE-2.0.html"
+host: "kuzzle.swagger.io"
+basePath: "/v2"
+tags:
+- name: "document"
+  description: "Everything about document action"
+  externalDocs:
+    description: "More about document action"
+    url: "https://docs.kuzzle.io/core/1/api/essentials/connecting-to-kuzzle/"
+schemes:
+- "https"
+- "http"
+paths:
+  /document/count:
+    $ref: "./documents/count.yaml#/DocumentCount"

--- a/doc/swagger/swagger/api.yaml
+++ b/doc/swagger/swagger/api.yaml
@@ -33,3 +33,5 @@ paths:
     $ref: "./documents/deleteByQuery.yaml#/DocumentDeleteByQuery"
   /document/get:
     $ref: "./documents/get.yaml#/DocumentGet"
+  /document/replace:
+    $ref: "./documents/replace.yaml#/DocumentReplace"

--- a/doc/swagger/swagger/api.yaml
+++ b/doc/swagger/swagger/api.yaml
@@ -27,3 +27,5 @@ paths:
     $ref: "./documents/create.yaml#/DocumentCreate"
   /document/createOrReplace:
     $ref: "./documents/createOrReplace.yaml#/DocumentCreateOrReplace"
+  /document/delete:
+    $ref: "./documents/delete.yaml#/DocumentDelete"

--- a/doc/swagger/swagger/api.yaml
+++ b/doc/swagger/swagger/api.yaml
@@ -29,3 +29,5 @@ paths:
     $ref: "./documents/createOrReplace.yaml#/DocumentCreateOrReplace"
   /document/delete:
     $ref: "./documents/delete.yaml#/DocumentDelete"
+  /document/deleteByQuery:
+    $ref: "./documents/deleteByQuery.yaml#/DocumentDeleteByQuery"

--- a/doc/swagger/swagger/api.yaml
+++ b/doc/swagger/swagger/api.yaml
@@ -25,3 +25,5 @@ paths:
     $ref: "./documents/count.yaml#/DocumentCount"
   /document/create:
     $ref: "./documents/create.yaml#/DocumentCreate"
+  /document/createOrReplace:
+    $ref: "./documents/createOrReplace.yaml#/DocumentCreateOrReplace"

--- a/doc/swagger/swagger/api.yaml
+++ b/doc/swagger/swagger/api.yaml
@@ -23,3 +23,5 @@ schemes:
 paths:
   /document/count:
     $ref: "./documents/count.yaml#/DocumentCount"
+  /document/create:
+    $ref: "./documents/create.yaml#/DocumentCreate"

--- a/doc/swagger/swagger/api.yaml
+++ b/doc/swagger/swagger/api.yaml
@@ -31,3 +31,5 @@ paths:
     $ref: "./documents/delete.yaml#/DocumentDelete"
   /document/deleteByQuery:
     $ref: "./documents/deleteByQuery.yaml#/DocumentDeleteByQuery"
+  /document/get:
+    $ref: "./documents/get.yaml#/DocumentGet"

--- a/doc/swagger/swagger/api.yaml
+++ b/doc/swagger/swagger/api.yaml
@@ -35,3 +35,5 @@ paths:
     $ref: "./documents/get.yaml#/DocumentGet"
   /document/replace:
     $ref: "./documents/replace.yaml#/DocumentReplace"
+  /document/update:
+    $ref: "./documents/update.yaml#/DocumentUpdate"

--- a/doc/swagger/swagger/documents/count.yaml
+++ b/doc/swagger/swagger/documents/count.yaml
@@ -9,21 +9,25 @@ DocumentCount:
         description: "Counts documents in a collection."
         required: true
         schema:
-          $ref: "./definitions.yaml#/definitions/document"
+          $ref: "#/components/schemas/CountRequest"
     responses:
       200:
         description: "Counts documents in a collection."
         schema:
-          $ref: "./definitions.yaml#/definitions/response"
+          $ref: "#/components/schemas/CountResponse"
 
 components:
   schemas:
-    User:
-      type: object
-      properties:
-        id:
-          type: integer
-          description: The user ID.
-        username:
-          type: string
-          description: The user name.
+    CountRequest:
+      allOf:
+        - $ref: "./definitions.yaml#/definitions/BasicRequest"
+    CountResponse:
+      allOf:
+        - $ref: "./definitions.yaml#/definitions/BasicResponse"
+        - type: "object"
+          properties:
+            result:
+              type: "object"
+              properties:
+                count:
+                  type: "integer"

--- a/doc/swagger/swagger/documents/count.yaml
+++ b/doc/swagger/swagger/documents/count.yaml
@@ -1,0 +1,29 @@
+DocumentCount:
+  post:
+    summary: "Counts documents in a collection."
+    tags:
+      - document
+    parameters:
+      - name: body
+        in: "body"
+        description: "Counts documents in a collection."
+        required: true
+        schema:
+          $ref: "./definitions.yaml#/definitions/document"
+    responses:
+      200:
+        description: "Counts documents in a collection."
+        schema:
+          $ref: "./definitions.yaml#/definitions/response"
+
+components:
+  schemas:
+    User:
+      type: object
+      properties:
+        id:
+          type: integer
+          description: The user ID.
+        username:
+          type: string
+          description: The user name.

--- a/doc/swagger/swagger/documents/create.yaml
+++ b/doc/swagger/swagger/documents/create.yaml
@@ -1,0 +1,43 @@
+DocumentCreate:
+  post:
+    summary: "Creates a new document in the persistent data storage."
+    tags:
+      - document
+    parameters:
+      - name: body
+        in: "body"
+        description: "Creates a new document in the persistent data storage."
+        required: true
+        schema:
+          $ref: "#/components/schemas/CreateRequest"
+    responses:
+      200:
+        description: "Creates a new document in the persistent data storage."
+        schema:
+            $ref: "#/components/schemas/CreateResponse"
+
+components:
+  schemas:
+    CreateRequest:
+      allOf:
+        - $ref: "./definitions.yaml#/definitions/BasicRequest"
+        - type: "object"
+          properties:
+            _id:
+              type: "string"
+              description: "documentId"
+    CreateResponse:
+      allOf:
+        - $ref: "./definitions.yaml#/definitions/BasicResponse"
+        - type: "object"
+          properties:
+            result:
+              type: "object"
+              properties:
+                _id:
+                  type: "string"
+                  description: "documentId"
+                _version:
+                  type: "integer"
+                _sources:
+                  type: "object"

--- a/doc/swagger/swagger/documents/createOrReplace.yaml
+++ b/doc/swagger/swagger/documents/createOrReplace.yaml
@@ -1,5 +1,5 @@
 DocumentCreateOrReplace:
-  post:
+  put:
     summary: "Creates a new document in the persistent data storage, or replaces its content if it already exists."
     tags:
       - document

--- a/doc/swagger/swagger/documents/createOrReplace.yaml
+++ b/doc/swagger/swagger/documents/createOrReplace.yaml
@@ -1,0 +1,48 @@
+DocumentCreateOrReplace:
+  post:
+    summary: "Creates a new document in the persistent data storage, or replaces its content if it already exists."
+    tags:
+      - document
+    parameters:
+      - name: body
+        in: "body"
+        description: "Creates a new document in the persistent data storage, or replaces its content if it already exists."
+        required: true
+        schema:
+          $ref: "#/components/schemas/CreateOrReplaceRequest"
+    responses:
+      200:
+        description: "Creates a new document in the persistent data storage, or replaces its content if it already exists."
+        schema:
+          $ref: "#/components/schemas/CreateOrReplaceResponse"
+
+components:
+  schemas:
+    CreateOrReplaceRequest:
+      allOf:
+        - $ref: "./definitions.yaml#/definitions/BasicRequest"
+        - type: "object"
+          properties:
+            _id:
+              type: "string"
+              description: "documentId"
+            refresh:
+              type: "string"
+              description: " if set to wait_for, Kuzzle will not respond until the created/replaced document is indexed"
+    CreateOrReplaceResponse:
+      allOf:
+        - $ref: "./definitions.yaml#/definitions/BasicResponse"
+        - type: "object"
+          properties:
+            result:
+              type: "object"
+              properties:
+                _id:
+                  type: "string"
+                  description: "documentId"
+                _version:
+                  type: "integer"
+                _sources:
+                  type: "object"
+                created:
+                  type: "boolean"

--- a/doc/swagger/swagger/documents/definitions.yaml
+++ b/doc/swagger/swagger/documents/definitions.yaml
@@ -1,0 +1,37 @@
+definitions:
+  document:
+    type: "object"
+    properties:
+      controller:
+        type: "string"
+        enum: "document"
+      action:
+        type: "string"
+        enum: "count"
+      index:
+        type: "string"
+      collection:
+        type: "string"
+  response:
+    type: "object"
+    properties:
+      status:
+        type: "integer"
+      error:
+        type: "object"
+      index:
+        type: "string"
+      collection:
+        type: "string"
+      controller:
+        type: "string"
+      action:
+        type: "string"
+      requestId:
+        type: "integer"
+        description: "unique request identifie"
+      result:
+        type: "object"
+        properties:
+          count:
+            type: "integer"

--- a/doc/swagger/swagger/documents/definitions.yaml
+++ b/doc/swagger/swagger/documents/definitions.yaml
@@ -1,5 +1,5 @@
 definitions:
-  document:
+  BasicRequest:
     type: "object"
     properties:
       controller:
@@ -12,7 +12,7 @@ definitions:
         type: "string"
       collection:
         type: "string"
-  response:
+  BasicResponse:
     type: "object"
     properties:
       status:
@@ -30,8 +30,3 @@ definitions:
       requestId:
         type: "integer"
         description: "unique request identifie"
-      result:
-        type: "object"
-        properties:
-          count:
-            type: "integer"

--- a/doc/swagger/swagger/documents/delete.yaml
+++ b/doc/swagger/swagger/documents/delete.yaml
@@ -1,0 +1,42 @@
+DocumentDelete:
+  post:
+    summary: "Deletes a document."
+    tags:
+      - document
+    parameters:
+      - name: body
+        in: "body"
+        description: "Deletes a document."
+        required: true
+        schema:
+          $ref: "#/components/schemas/DeleteRequest"
+    responses:
+      200:
+        description: "Deletes a document."
+        schema:
+          $ref: "#/components/schemas/DeleteResponse"
+
+components:
+  schemas:
+    DeleteRequest:
+      allOf:
+        - $ref: "./definitions.yaml#/definitions/BasicRequest"
+        - type: "object"
+          properties:
+            _id:
+              type: "string"
+              description: "documentId"
+            refresh:
+              type: "string"
+              description: " if set to wait_for, Kuzzle will not respond until the created/replaced document is indexed"
+    DeleteResponse:
+      allOf:
+        - $ref: "./definitions.yaml#/definitions/BasicResponse"
+        - type: "object"
+          properties:
+            result:
+              type: "object"
+              properties:
+                _id:
+                  type: "string"
+                  description: "documentId"

--- a/doc/swagger/swagger/documents/delete.yaml
+++ b/doc/swagger/swagger/documents/delete.yaml
@@ -1,5 +1,5 @@
 DocumentDelete:
-  post:
+  delete:
     summary: "Deletes a document."
     tags:
       - document

--- a/doc/swagger/swagger/documents/deleteByQuery.yaml
+++ b/doc/swagger/swagger/documents/deleteByQuery.yaml
@@ -1,0 +1,43 @@
+DocumentDeleteByQuery:
+  post:
+    summary: "Deletes documents matching the provided search query."
+    tags:
+      - document
+    parameters:
+      - name: body
+        in: "body"
+        description: "Deletes documents matching the provided search query."
+        required: true
+        schema:
+          $ref: "#/components/schemas/DeleteByQueryRequest"
+    responses:
+      200:
+        description: "Deletes documents matching the provided search query."
+        schema:
+          $ref: "#/components/schemas/DeleteByQueryResponse"
+
+components:
+  schemas:
+    DeleteByQueryRequest:
+      allOf:
+        - $ref: "./definitions.yaml#/definitions/BasicRequest"
+        - type: "object"
+          properties:
+            body:
+              type: "object"
+              properties:
+                query:
+                  type: "object"
+                  description: "documents matching this search query will be deleted. Uses the ElasticSearch Query DSL syntax."
+    DeleteByQueryResponse:
+      allOf:
+        - $ref: "./definitions.yaml#/definitions/BasicResponse"
+        - type: "object"
+          properties:
+            result:
+              type: "object"
+              properties:
+                ids:
+                  type: "array"
+                  items:
+                    type: "string"

--- a/doc/swagger/swagger/documents/deleteByQuery.yaml
+++ b/doc/swagger/swagger/documents/deleteByQuery.yaml
@@ -1,5 +1,5 @@
 DocumentDeleteByQuery:
-  post:
+  delete:
     summary: "Deletes documents matching the provided search query."
     tags:
       - document

--- a/doc/swagger/swagger/documents/get.yaml
+++ b/doc/swagger/swagger/documents/get.yaml
@@ -1,0 +1,58 @@
+DocumentGet:
+  get:
+    summary: "Gets a document."
+    tags:
+      - document
+    parameters:
+      - name: body
+        in: "body"
+        description: "Gets a document."
+        required: true
+        schema:
+          $ref: "#/components/schemas/CreateRequest"
+    responses:
+      200:
+        description: "Gets a document."
+        schema:
+            $ref: "#/components/schemas/CreateResponse"
+
+components:
+  schemas:
+    CreateRequest:
+      allOf:
+        - $ref: "./definitions.yaml#/definitions/BasicRequest"
+        - type: "object"
+          properties:
+            _id:
+              type: "string"
+              description: "documentId"
+            includeTrash:
+              type: "boolean"
+              description: "if true, documents in the trashcan can be returned"
+    CreateResponse:
+      allOf:
+        - $ref: "./definitions.yaml#/definitions/BasicResponse"
+        - type: "object"
+          properties:
+            result:
+              type: "object"
+              properties:
+                _id:
+                  type: "string"
+                  description: "documentId"
+                _version:
+                  type: "integer"
+                _sources:
+                  type: "object"
+                  description: "document content"
+                  properties:
+                    name:
+                      type: "object"
+                      properties:
+                        first:
+                          type: "string"
+                        last:
+                          type: "string"
+                    _kuzzle_info:
+                      type: "object"
+                      description: "Information about the Kuzzle documents"

--- a/doc/swagger/swagger/documents/get.yaml
+++ b/doc/swagger/swagger/documents/get.yaml
@@ -9,16 +9,16 @@ DocumentGet:
         description: "Gets a document."
         required: true
         schema:
-          $ref: "#/components/schemas/CreateRequest"
+          $ref: "#/components/schemas/GetRequest"
     responses:
       200:
         description: "Gets a document."
         schema:
-            $ref: "#/components/schemas/CreateResponse"
+            $ref: "#/components/schemas/GetResponse"
 
 components:
   schemas:
-    CreateRequest:
+    GetRequest:
       allOf:
         - $ref: "./definitions.yaml#/definitions/BasicRequest"
         - type: "object"
@@ -29,7 +29,7 @@ components:
             includeTrash:
               type: "boolean"
               description: "if true, documents in the trashcan can be returned"
-    CreateResponse:
+    GetResponse:
       allOf:
         - $ref: "./definitions.yaml#/definitions/BasicResponse"
         - type: "object"

--- a/doc/swagger/swagger/documents/replace.yaml
+++ b/doc/swagger/swagger/documents/replace.yaml
@@ -1,0 +1,49 @@
+DocumentReplace:
+  put:
+    summary: "Replaces the content of an existing document."
+    tags:
+      - document
+    parameters:
+      - name: body
+        in: "body"
+        description: "Replaces the content of an existing document."
+        required: true
+        schema:
+          $ref: "#/components/schemas/ReplaceRequest"
+    responses:
+      200:
+        description: "Replaces the content of an existing document."
+        schema:
+          $ref: "#/components/schemas/ReplaceResponse"
+
+components:
+  schemas:
+    ReplaceRequest:
+      allOf:
+        - $ref: "./definitions.yaml#/definitions/BasicRequest"
+        - type: "object"
+          properties:
+            _id:
+              type: "string"
+              description: "documentId"
+            refresh:
+              type: "string"
+              description: " if set to wait_for, Kuzzle will not respond until the created/replaced document is indexed"
+            body:
+              type: "string"
+    ReplaceResponse:
+      allOf:
+        - $ref: "./definitions.yaml#/definitions/BasicResponse"
+        - type: "object"
+          properties:
+            result:
+              type: "object"
+              properties:
+                _id:
+                  type: "string"
+                  description: "documentId"
+                _version:
+                  type: "integer"
+                _sources:
+                  type: "object"
+                  description: "new document content"

--- a/doc/swagger/swagger/documents/update.yaml
+++ b/doc/swagger/swagger/documents/update.yaml
@@ -1,0 +1,49 @@
+DocumentUpdate:
+  put:
+    summary: "Updates a document content."
+    tags:
+      - document
+    parameters:
+      - name: body
+        in: "body"
+        description: "Updates a document content."
+        required: true
+        schema:
+          $ref: "#/components/schemas/UpdateRequest"
+    responses:
+      200:
+        description: "Updates a document content."
+        schema:
+          $ref: "#/components/schemas/UpdateResponse"
+
+components:
+  schemas:
+    UpdateRequest:
+      allOf:
+        - $ref: "./definitions.yaml#/definitions/BasicRequest"
+        - type: "object"
+          properties:
+            _id:
+              type: "string"
+              description: "documentId"
+            refresh:
+              type: "string"
+              description: " if set to wait_for, Kuzzle will not respond until the created/replaced document is indexed"
+            body:
+              type: "string"
+            retryOnConflict:
+              type: "string"
+              description: "conflicts may occur if the same document gets updated multiple times within a short timespan, in a database cluster. You can set the retryOnConflict optional argument (with a retry count), to tell Kuzzle to retry the failing updates the specified amount of times before rejecting the request with an error."
+    UpdateResponse:
+      allOf:
+        - $ref: "./definitions.yaml#/definitions/BasicResponse"
+        - type: "object"
+          properties:
+            result:
+              type: "object"
+              properties:
+                _id:
+                  type: "string"
+                  description: "documentId"
+                _version:
+                  type: "integer"

--- a/package.json
+++ b/package.json
@@ -131,7 +131,8 @@
     "test:lint:fix": "eslint src/ test/ --ext .ts --fix",
     "test:functional": "npm run build && npm run test:functional:stdout && npm run test:functional:cucumber",
     "test:functional:stdout": "nyc --extension .ts mocha --forbid-only \"test/**/*.test.ts\"",
-    "test:functional:cucumber": "./node_modules/.bin/cucumber-js"
+    "test:functional:cucumber": "./node_modules/.bin/cucumber-js",
+    "doc:swagger": "docker-compose -f doc/swagger/docker-compose.yaml up"
   },
   "types": "lib/index.d.ts"
 }


### PR DESCRIPTION
⚠️ Depends on [#2165](https://github.com/kuzzleio/kuzzle/issues/2165)

## What does this PR do ?

This PR adds an initial implementation of swagger-ui and describes the document controller's counting action.

### How should this be manually tested?

```npm run doc:swagger```

### Other changes

Add docker-compose file to create a container with swagger image
Add package.json script to run the swagger ui.
Add README.md file for my ressources

PS: I will delete the launch script for swagger, as soon as I finish the documentation and add a command to kourou