### PR TITLE
Add ES6 library dependency in project scaffold

### DIFF
--- a/templates/app-scaffold/ts/tsconfig.json
+++ b/templates/app-scaffold/ts/tsconfig.json
@@ -1,5 +1,6 @@
 {
   "compilerOptions": {
+    "lib": ["ES6"],
     "declaration": true,
     "listEmittedFiles": true,
     "module": "commonjs",


### PR DESCRIPTION
**Note:** this is my first PR for Kuzzle, please let me know if I have to modify it to match your expectations.

## What does this PR do?
Currently when developing a Kuzzle app, TypeScript always suggests and uses browser objects (like `window` or `crypto`) and types (like `Location`).
With this PR TypeScript is instructed to only provide native ES6 objects and types (like `Set`).

### How should this be manually tested?

- Use Visual Studio Code
- Scaffold a project with kourou before applying this PR
  - try using `window.location` in your `app.ts`
  - you will get code suggestions for this
- Apply these changes to your `tsconfig.json`
  - Note: you may have to restart the TS server after modifying `tsconfig.json`
  - try using `window.location` in your `app.ts`
  - you will not see any suggestions and `window` will be marked as `Cannot find name 'window'. ts(2304)`
