### PR TITLE
Perform a Docker Compose pull when scaffolding

### DIFF
--- a/src/commands/app/scaffold.ts
+++ b/src/commands/app/scaffold.ts
@@ -73,8 +73,10 @@ export default class AppScaffold extends Kommand {
       },
       {
         title: 'Installing dependencies (this can take some time)',
-        task: () =>
+        task: () => {
+          execute('docker-compose', 'pull')
           execute('npm', 'run', 'install:docker', { cwd: this.args.name })
+        }
       },
     ]);
 


### PR DESCRIPTION

### Why?

Because if something get wrong with the images used in the `docker-compose.yml` file, we would be able to make it easy for users to upgrade their stacks

