### PR TITLE
0.24.1: Fix scaffold and encrypt command

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ npm install -g kourou
 $ kourou COMMAND
 running command...
 $ kourou (-v|--version|version)
-kourou/0.24.0 darwin-x64 node-v14.18.2
+kourou/0.24.1 linux-x64 node-v16.13.2
 $ kourou --help [COMMAND]
 USAGE
   $ kourou COMMAND
@@ -198,7 +198,6 @@ OPTIONS
   --port=port          [default: 7512] Kuzzle server port
   --protocol=protocol  [default: ws] Kuzzle protocol (http or ws)
   --ssl                Use SSL to connect to Kuzzle
-  --ttl=ttl            [default: 90] Kuzzle login TTL (in seconds)
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 
 EXAMPLE
@@ -230,7 +229,6 @@ OPTIONS
   --port=port                    [default: 7512] Kuzzle server port
   --protocol=protocol            [default: ws] Kuzzle protocol (http or ws)
   --ssl                          Use SSL to connect to Kuzzle
-  --ttl=ttl                      [default: 90] Kuzzle login TTL (in seconds)
   --username=username            [default: anonymous] Kuzzle username (local strategy)
 ```
 
@@ -257,7 +255,6 @@ OPTIONS
   --port=port          [default: 7512] Kuzzle server port
   --protocol=protocol  [default: ws] Kuzzle protocol (http or ws)
   --ssl                Use SSL to connect to Kuzzle
-  --ttl=ttl            [default: 90] Kuzzle login TTL (in seconds)
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 
 EXAMPLE
@@ -287,7 +284,6 @@ OPTIONS
   --port=port          [default: 7512] Kuzzle server port
   --protocol=protocol  [default: ws] Kuzzle protocol (http or ws)
   --ssl                Use SSL to connect to Kuzzle
-  --ttl=ttl            [default: 90] Kuzzle login TTL (in seconds)
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 ```
 
@@ -385,7 +381,7 @@ EXAMPLES
   $ kourou autocomplete --refresh-cache
 ```
 
-_See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomplete/blob/v1.3.0/src/commands/autocomplete/index.ts)_
+_See code: [@oclif/plugin-autocomplete](https://github.com/oclif/plugin-autocomplete/blob/v1.2.0/src/commands/autocomplete/index.ts)_
 
 ## `kourou collection:create INDEX COLLECTION [BODY]`
 
@@ -409,7 +405,6 @@ OPTIONS
   --port=port          [default: 7512] Kuzzle server port
   --protocol=protocol  [default: ws] Kuzzle protocol (http or ws)
   --ssl                Use SSL to connect to Kuzzle
-  --ttl=ttl            [default: 90] Kuzzle login TTL (in seconds)
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 ```
 
@@ -482,9 +477,6 @@ OPTIONS
   --ssl
       Use SSL to connect to Kuzzle
 
-  --ttl=ttl
-      [default: 90] Kuzzle login TTL (in seconds)
-
   --username=username
       [default: anonymous] Kuzzle username (local strategy)
 
@@ -519,7 +511,6 @@ OPTIONS
   --port=port              [default: 7512] Kuzzle server port
   --protocol=protocol      [default: ws] Kuzzle protocol (http or websocket)
   --ssl                    Use SSL to connect to Kuzzle
-  --ttl=ttl                [default: 90] Kuzzle login TTL (in seconds)
   --username=username      [default: anonymous] Kuzzle username (local strategy)
 ```
 
@@ -575,7 +566,6 @@ OPTIONS
   --size=size          Optional page size
   --sort=sort          [default: {}] Sort in JS or JSON format.
   --ssl                Use SSL to connect to Kuzzle
-  --ttl=ttl            [default: 90] Kuzzle login TTL (in seconds)
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 
 EXAMPLES
@@ -830,7 +820,6 @@ OPTIONS
   --preserve-anonymous     Preserve anonymous rights
   --protocol=protocol      [default: ws] Kuzzle protocol (http or websocket)
   --ssl                    Use SSL to connect to Kuzzle
-  --ttl=ttl                [default: 90] Kuzzle login TTL (in seconds)
   --username=username      [default: anonymous] Kuzzle username (local strategy)
 ```
 
@@ -871,8 +860,6 @@ OPTIONS
 
   --ssl                    Use SSL to connect to Kuzzle
 
-  --ttl=ttl                [default: 90] Kuzzle login TTL (in seconds)
-
   --username=username      [default: anonymous] Kuzzle username (local strategy)
 
 EXAMPLES
@@ -905,7 +892,6 @@ OPTIONS
   --port=port              [default: 7512] Kuzzle server port
   --protocol=protocol      [default: ws] Kuzzle protocol (http or websocket)
   --ssl                    Use SSL to connect to Kuzzle
-  --ttl=ttl                [default: 90] Kuzzle login TTL (in seconds)
   --username=username      [default: anonymous] Kuzzle username (local strategy)
 
 EXAMPLES
@@ -1063,7 +1049,6 @@ OPTIONS
   --port=port          [default: 7512] Kuzzle server port
   --protocol=protocol  [default: ws] Kuzzle protocol (http or websocket)
   --ssl                Use SSL to connect to Kuzzle
-  --ttl=ttl            [default: 90] Kuzzle login TTL (in seconds)
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 ```
 
@@ -1089,7 +1074,6 @@ OPTIONS
   --port=port          [default: 7512] Kuzzle server port
   --protocol=protocol  [default: ws] Kuzzle protocol (http or websocket)
   --ssl                Use SSL to connect to Kuzzle
-  --ttl=ttl            [default: 90] Kuzzle login TTL (in seconds)
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 ```
 
@@ -1131,8 +1115,6 @@ OPTIONS
 
   --ssl                Use SSL to connect to Kuzzle
 
-  --ttl=ttl            [default: 90] Kuzzle login TTL (in seconds)
-
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 
   --users=users        [default: all] Subscribe to users entering or leaving the room (all, in, out, none)
@@ -1172,7 +1154,6 @@ OPTIONS
   --remove             Remove matching keys
   --size=size          [default: 100] Page size
   --ssl                Use SSL to connect to Kuzzle
-  --ttl=ttl            [default: 90] Kuzzle login TTL (in seconds)
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 
 EXAMPLES
@@ -1200,7 +1181,6 @@ OPTIONS
   --port=port          [default: 7512] Kuzzle server port
   --protocol=protocol  [default: ws] Kuzzle protocol (http or websocket)
   --ssl                Use SSL to connect to Kuzzle
-  --ttl=ttl            [default: 90] Kuzzle login TTL (in seconds)
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 ```
 
@@ -1227,7 +1207,6 @@ OPTIONS
   --preserve-anonymous  Preserve anonymous rights
   --protocol=protocol   [default: ws] Kuzzle protocol (http or websocket)
   --ssl                 Use SSL to connect to Kuzzle
-  --ttl=ttl             [default: 90] Kuzzle login TTL (in seconds)
   --username=username   [default: anonymous] Kuzzle username (local strategy)
 ```
 
@@ -1257,7 +1236,6 @@ OPTIONS
   --print-raw          Print only the script result to stdout
   --protocol=protocol  [default: ws] Kuzzle protocol (http or ws)
   --ssl                Use SSL to connect to Kuzzle
-  --ttl=ttl            [default: 90] Kuzzle login TTL (in seconds)
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 
 DESCRIPTION
@@ -1330,8 +1308,6 @@ OPTIONS
   --protocol=protocol          [default: ws] Kuzzle protocol (http or ws)
 
   --ssl                        Use SSL to connect to Kuzzle
-
-  --ttl=ttl                    [default: 90] Kuzzle login TTL (in seconds)
 
   --username=username          [default: anonymous] Kuzzle username (local strategy)
 
@@ -1415,7 +1391,6 @@ OPTIONS
   --port=port                              [default: 7512] Kuzzle server port
   --protocol=protocol                      [default: ws] Kuzzle protocol (http or websocket)
   --ssl                                    Use SSL to connect to Kuzzle
-  --ttl=ttl                                [default: 90] Kuzzle login TTL (in seconds)
   --username=username                      [default: anonymous] Kuzzle username (local strategy)
 
 DESCRIPTION
@@ -1464,7 +1439,6 @@ OPTIONS
   --port=port          [default: 7512] Kuzzle server port
   --protocol=protocol  [default: ws] Kuzzle protocol (http or websocket)
   --ssl                Use SSL to connect to Kuzzle
-  --ttl=ttl            [default: 90] Kuzzle login TTL (in seconds)
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 ```
 
@@ -1490,7 +1464,6 @@ OPTIONS
   --port=port          [default: 7512] Kuzzle server port
   --protocol=protocol  [default: ws] Kuzzle protocol (http or websocket)
   --ssl                Use SSL to connect to Kuzzle
-  --ttl=ttl            [default: 90] Kuzzle login TTL (in seconds)
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 ```
 
@@ -1516,7 +1489,6 @@ OPTIONS
   --port=port          [default: 7512] Kuzzle server port
   --protocol=protocol  [default: ws] Kuzzle protocol (http or websocket)
   --ssl                Use SSL to connect to Kuzzle
-  --ttl=ttl            [default: 90] Kuzzle login TTL (in seconds)
   --username=username  [default: anonymous] Kuzzle username (local strategy)
 ```
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kourou",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kourou",
-      "version": "0.24.0",
+      "version": "0.24.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/elasticsearch": "^7.12.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kourou",
   "description": "The CLI that helps you manage your Kuzzle instances",
-  "version": "0.24.0",
+  "version": "0.24.1",
   "author": "The Kuzzle Team <support@kuzzle.io>",
   "bin": {
     "kourou": "./bin/run"

--- a/src/commands/app/scaffold.ts
+++ b/src/commands/app/scaffold.ts
@@ -41,10 +41,14 @@ export default class AppScaffold extends Kommand {
   }
 
   async cloneTemplate(flavor: string, destination: string) {
-    await execute('git', 'clone', '--depth=1', 'https://github.com/kuzzleio/project-templates', '--branch', flavor, '--single-branch');
+    const templatesDir = '/tmp/project-templates';
 
-    await execute('mv', `project-templates/${flavor}`, `${destination}/`);
+    await execute('rm', '-rf', templatesDir);
 
-    await execute('rm', '-rf', 'project-templates/');
+    await execute('git', 'clone', '--depth=1', 'https://github.com/kuzzleio/project-templates', '--branch', flavor, '--single-branch', templatesDir);
+
+    await execute('cp', '-r', `${templatesDir}/${flavor}`, `${destination}/`);
+
+    await execute('rm', '-rf', templatesDir);
   }
 }

--- a/src/commands/vault/encrypt.ts
+++ b/src/commands/vault/encrypt.ts
@@ -1,4 +1,5 @@
 import fs from 'fs'
+import path from 'path'
 
 import _ from 'lodash'
 import { flags } from '@oclif/command'
@@ -61,8 +62,9 @@ See https://github.com/kuzzleio/kuzzle-vault/ for more information.
       throw new Error('A secrets file must be provided')
     }
 
-    const [filename, ext] = this.args.file.split('.')
-    let outputFile = `${filename}.enc.${ext}`
+    const { name, ext } = path.parse(this.args.file);
+    let outputFile = `${name}.enc.${ext}`
+
     if (this.flags['output-file']) {
       outputFile = this.flags['output-file']
     }

--- a/src/commands/vault/encrypt.ts
+++ b/src/commands/vault/encrypt.ts
@@ -63,7 +63,7 @@ See https://github.com/kuzzleio/kuzzle-vault/ for more information.
     }
 
     const { name, ext } = path.parse(this.args.file);
-    let outputFile = `${name}.enc.${ext}`
+    let outputFile = `${name}.enc${ext}`
 
     if (this.flags['output-file']) {
       outputFile = this.flags['output-file']


### PR DESCRIPTION
## What does this PR do?

Fix the following bug:
 - `app:scaffold`: download project-templates in a temporary and clean directory to avoid conflicts
 - `vault:encrypt`: support `.` in vault file path (fix https://github.com/kuzzleio/kourou/issues/153)
