### PR TITLE
Prevent cluster node eviction while debugging

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -15,6 +15,7 @@
     "no-shadow": "off",
     "@typescript-eslint/no-shadow": "error",
     "@typescript-eslint/no-explicit-any": 0,
-    "@typescript-eslint/explicit-module-boundary-types": 0
+    "@typescript-eslint/explicit-module-boundary-types": 0,
+    "@typescript-eslint/ban-ts-comment": 0
   }
 }


### PR DESCRIPTION
## What does this PR do?

- Ask Kuzzle to prevent the node from being evicted while debugging when starting the debug-proxy
- Prevent the SDK from disconnecting itself because of the websocket `ping pong` while debugging because Kuzzle can be slow to respond