### PR TITLE
Be able to ignore PaaS specific processes and only login to NPM private package registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ npm install -g kourou
 $ kourou COMMAND
 running command...
 $ kourou (-v|--version|version)
-kourou/0.24.1 linux-x64 node-v16.13.2
+kourou/0.24.2 darwin-x64 node-v16.17.0
 $ kourou --help [COMMAND]
 USAGE
   $ kourou COMMAND
@@ -1006,6 +1006,7 @@ USAGE
 
 OPTIONS
   --help               show CLI help
+  --only_npm           Only perform the login on the private NPM registry
   --project=project    Current PaaS project
   --username=username  PaaS username
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kourou",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kourou",
-      "version": "0.24.1",
+      "version": "0.24.2",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/elasticsearch": "^7.12.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kourou",
   "description": "The CLI that helps you manage your Kuzzle instances",
-  "version": "0.24.1",
+  "version": "0.24.2",
   "author": "The Kuzzle Team <support@kuzzle.io>",
   "bin": {
     "kourou": "./bin/run"

--- a/src/commands/paas/login.ts
+++ b/src/commands/paas/login.ts
@@ -14,11 +14,16 @@ class PaasLogin extends PaasKommand {
   public static flags = {
     help: flags.help(),
     project: flags.string({
-      description: 'Current PaaS project'
+      description: 'Current PaaS project',
+      required: false
     }),
     username: flags.string({
       description: 'PaaS username',
     }),
+    only_npm: flags.boolean({
+      description: 'Only perform the login on the private NPM registry',
+      required: false
+    })
   };
 
   async runSafe() {
@@ -31,6 +36,11 @@ class PaasLogin extends PaasKommand {
     const password = process.env.KUZZLE_PAAS_PASSWORD
       ? process.env.KUZZLE_PAAS_PASSWORD
       : await cli.prompt(`    Password`, { type: 'hide' });
+
+    if (this.flags.only_npm) {
+      await this.authenticateNPM(username, password);
+      return;
+    }
 
     await this.initPaasClient({ username, password });
 

--- a/src/commands/paas/login.ts
+++ b/src/commands/paas/login.ts
@@ -22,7 +22,8 @@ class PaasLogin extends PaasKommand {
     }),
     only_npm: flags.boolean({
       description: 'Only perform the login on the private NPM registry',
-      required: false
+      required: false,
+      default: false
     })
   };
 


### PR DESCRIPTION
## What does this PR do?
Add flag on `paas:login` command to only perform the automated NPM login action (useful for Premium Licence users who don't owning a PaaS environment)
