### PR TITLE
0.24.3 - Increase scroll TTL for export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "kourou",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "kourou",
-      "version": "0.24.2",
+      "version": "0.24.3",
       "license": "Apache-2.0",
       "dependencies": {
         "@elastic/elasticsearch": "^7.12.0",
@@ -23,7 +23,7 @@
         "cli-ux": "^5.5.1",
         "inquirer": "^8.0.0",
         "kepler-companion": "^1.1.3",
-        "kuzzle-sdk": "^7.8.4",
+        "kuzzle-sdk": "^7.10.1",
         "kuzzle-vault": "^2.0.4",
         "listr": "^0.14.3",
         "lodash": "^4.17.21",
@@ -6018,12 +6018,12 @@
       }
     },
     "node_modules/kuzzle-sdk": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/kuzzle-sdk/-/kuzzle-sdk-7.10.0.tgz",
-      "integrity": "sha512-bo21mWmCatOVpijONC0c/RYwCOLtURDxBM8wyEu8u4R8xtGLENbKE55AjNHYeyhI594dP3YfiQTOirBqeurEFQ==",
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/kuzzle-sdk/-/kuzzle-sdk-7.10.1.tgz",
+      "integrity": "sha512-tz8yZmka5HcO1JCi3KYfoUiWtozBMMdO4ViKMh8XHLKhbEBvJRK7Jici5e8BCVj80H/8DlgF5HBXmb45v0PxAg==",
       "dependencies": {
         "min-req-promise": "^1.0.1",
-        "ws": "^8.4.2"
+        "ws": "^8.8.1"
       },
       "engines": {
         "node": ">= 10.13.0"
@@ -14361,12 +14361,12 @@
       }
     },
     "kuzzle-sdk": {
-      "version": "7.10.0",
-      "resolved": "https://registry.npmjs.org/kuzzle-sdk/-/kuzzle-sdk-7.10.0.tgz",
-      "integrity": "sha512-bo21mWmCatOVpijONC0c/RYwCOLtURDxBM8wyEu8u4R8xtGLENbKE55AjNHYeyhI594dP3YfiQTOirBqeurEFQ==",
+      "version": "7.10.1",
+      "resolved": "https://registry.npmjs.org/kuzzle-sdk/-/kuzzle-sdk-7.10.1.tgz",
+      "integrity": "sha512-tz8yZmka5HcO1JCi3KYfoUiWtozBMMdO4ViKMh8XHLKhbEBvJRK7Jici5e8BCVj80H/8DlgF5HBXmb45v0PxAg==",
       "requires": {
         "min-req-promise": "^1.0.1",
-        "ws": "^8.4.2"
+        "ws": "^8.8.1"
       }
     },
     "kuzzle-vault": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "kourou",
   "description": "The CLI that helps you manage your Kuzzle instances",
-  "version": "0.24.2",
+  "version": "0.24.3",
   "author": "The Kuzzle Team <support@kuzzle.io>",
   "bin": {
     "kourou": "./bin/run"
@@ -33,7 +33,7 @@
     "cli-ux": "^5.5.1",
     "inquirer": "^8.0.0",
     "kepler-companion": "^1.1.3",
-    "kuzzle-sdk": "^7.8.4",
+    "kuzzle-sdk": "^7.10.1",
     "kuzzle-vault": "^2.0.4",
     "listr": "^0.14.3",
     "lodash": "^4.17.21",

--- a/src/commands/collection/export.ts
+++ b/src/commands/collection/export.ts
@@ -45,7 +45,8 @@ exportable fields in the mapping will be exported.`
     }),
     scrollTTL: flags.string({
       description: `The scroll TTL option to pass to the dump operation (which performs a document.search under the hood),
-expressed in ms format, e.g. '2s', '1m', '3h'.`
+expressed in ms format, e.g. '2s', '1m', '3h'.`,
+      default: '20s'
     }),
     ...kuzzleFlags,
     protocol: flags.string({

--- a/src/support/dump-collection.ts
+++ b/src/support/dump-collection.ts
@@ -23,7 +23,7 @@ import { JSONObject, CollectionController } from 'kuzzle-sdk'
  * @param {Object} target the object we have to flatten
  * @returns {Object} the flattened object
  */
- function flattenObject(target: JSONObject): JSONObject {
+function flattenObject(target: JSONObject): JSONObject {
   const output = {};
 
   flattenStep(output, target);
@@ -37,7 +37,7 @@ function flattenStep(
   prev: string | null = null): void {
   const keys = Object.keys(object);
 
-  for(let i = 0; i < keys.length; i++) {
+  for (let i = 0; i < keys.length; i++) {
     const key = keys[i];
     const value = object[key];
     const newKey = prev ? prev + '.' + key : key;
@@ -55,7 +55,7 @@ abstract class AbstractDumper {
   protected collectionDir: string
   protected filename?: string
   protected writeStream?: fs.WriteStream
-  protected options: {scroll: string, size: number}
+  protected options: { scroll: string, size: number }
 
   protected abstract get fileExtension(): string
 
@@ -66,7 +66,7 @@ abstract class AbstractDumper {
     protected readonly batchSize: number,
     protected readonly destPath: string,
     protected readonly query: any = {},
-    protected readonly scrollTTL: string = '2s'
+    protected readonly scrollTTL: string = '20s'
   ) {
     this.collectionDir = path.join(this.destPath, this.collection)
     this.options = {
@@ -82,14 +82,14 @@ abstract class AbstractDumper {
    * @returns void
    */
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  public async setup() {}
+  public async setup() { }
 
   /**
    * One-shot call before iterating over the data. Can be
    * used to write the header of the dumped output.
    */
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  public async writeHeader() {}
+  public async writeHeader() { }
 
   /**
    * You can put here the logic to write into the dump.
@@ -107,10 +107,10 @@ abstract class AbstractDumper {
    *
    * @param document The document to be written in a line of the dump.
    */
-  abstract onResult(document: {_id: string, _source: any}): Promise<void>
+  abstract onResult(document: { _id: string, _source: any }): Promise<void>
 
   // eslint-disable-next-line @typescript-eslint/no-empty-function
-  public async tearDown() {}
+  public async tearDown() { }
 
   /**
    * The loop that iterates over the documents of the collection and
@@ -188,8 +188,8 @@ class JSONLDumper extends AbstractDumper {
       }
     })
   }
-  onResult(document: {_id: string, _source: any}): Promise<void> {
-    return this.writeLine({_id: document._id, body: document._source})
+  onResult(document: { _id: string, _source: any }): Promise<void> {
+    return this.writeLine({ _id: document._id, body: document._source })
   }
   protected get fileExtension() {
     return 'jsonl'
@@ -205,7 +205,7 @@ class KuzzleDumper extends JSONLDumper {
   protected get fileExtension() {
     return 'json'
   }
-  async onResult(document: {_id: string, _source: any}) {
+  async onResult(document: { _id: string, _source: any }) {
     this.rawDocuments[this.index][this.collection].push({
       index: {
         _id: document._id


### PR DESCRIPTION
## What does this PR do?
 
Increase the default scroll TTL to `20s` for export action to ensure the scroll page does not expire while being downloaded