### PR TITLE
Support custom NPM registry hostname with `paas:login`

### DIFF
--- a/src/support/PaasKommand.ts
+++ b/src/support/PaasKommand.ts
@@ -20,6 +20,9 @@ export class PaasKommand extends Kommand {
   protected ssl = process.env.KUZZLE_PAAS_SSL
     ? JSON.parse(process.env.KUZZLE_PAAS_SSL as string)
     : true;
+  protected packagesHost = process.env.KUZZLE_PAAS_PACKAGES_HOST
+    ? process.env.KUZZLE_PAAS_PACKAGES_HOST
+    : "packages.paas.kuzzle.io";
 
   // Instantiate a dummy SDK to avoid the this.paas? notation everywhere -_-
   protected paas = new KuzzleSDK({});


### PR DESCRIPTION
<!--
  This template is optional.
  It simply serves to provide a guide to allow a better review of pull requests.
-->

<!--
  IMPORTANT
  Don't forget to add the corresponding "changelog:xxx" label to your PR.
  This is part of our release process in order to generate the change log.
-->


## What does this PR do?
This PR adds a new environment variable, `KUZZLE_PAAS_PACKAGES_HOST`, which can be used to set the hostname of the NPM registry to login to.

This also adds a check to ensure that the login went successfully, throwing an error if it did not.