### PR TITLE
Fix `*:restore` commands and `paas:logs`

### DIFF
--- a/src/commands/paas/logs.ts
+++ b/src/commands/paas/logs.ts
@@ -135,21 +135,26 @@ class PaasLogs extends PaasKommand {
     // Display the response
     for await (const line of lineStream) {
       // Parse the data
-      const data: PaasLogData = JSON.parse(line);
+      try {
+        const data: PaasLogData = JSON.parse(line);
 
-      // Exclude logs that are empty or that are not from a pod
-      if (!data.content || !data.podName) {
-        continue;
+        // Exclude logs that are empty or that are not from a pod
+        if (!data.content || !data.podName) {
+          continue;
+        }
+
+        // Get the pod color
+        const podColor = this.getPodColor(data.podName);
+
+        // Display the log
+        const timestamp = this.flags.timestamp ? `[${new Date(data.timeStamp).toLocaleString()}] ` : "";
+        const name = podColor(`${data.podName}${separator}`);
+
+        this.log(`${timestamp}${name}| ${data.content}`);
       }
-
-      // Get the pod color
-      const podColor = this.getPodColor(data.podName);
-
-      // Display the log
-      const timestamp = this.flags.timestamp ? `[${new Date(data.timeStamp).toLocaleString()}] ` : "";
-      const name = podColor(`${data.podName}${separator}`);
-
-      this.log(`${timestamp}${name}| ${data.content}`);
+      catch (error) {
+        this.logKo(`Error while parsing log: ${error} (Received: "${line}")`);
+      }
     }
   }
 

--- a/src/support/kuzzle.ts
+++ b/src/support/kuzzle.ts
@@ -1,4 +1,5 @@
 import http from "http";
+import https from "https";
 
 import { flags } from "@oclif/command";
 import { Http, WebSocket, Kuzzle, JSONObject } from "kuzzle-sdk";
@@ -113,8 +114,7 @@ export class KuzzleSDK {
     this.sdk.on("networkError", (error: any) => logger.logKo(error.message));
 
     logger.logInfo(
-      `Connecting to ${this.protocol}${this.ssl ? "s" : ""}://${this.host}:${
-        this.port
+      `Connecting to ${this.protocol}${this.ssl ? "s" : ""}://${this.host}:${this.port
       } ...`
     );
 
@@ -227,7 +227,9 @@ export class KuzzleSDK {
 
     // Send the request
     return new Promise((resolve, reject) => {
-      const req = http.request(url, options, (res) => {
+      const httpModule = this.ssl ? https : http;
+
+      const req = httpModule.request(url, options, (res) => {
         resolve(res);
       });
 

--- a/src/support/kuzzle.ts
+++ b/src/support/kuzzle.ts
@@ -114,8 +114,7 @@ export class KuzzleSDK {
     this.sdk.on("networkError", (error: any) => logger.logKo(error.message));
 
     logger.logInfo(
-      `Connecting to ${this.protocol}${this.ssl ? "s" : ""}://${this.host}:${this.port
-      } ...`
+      `Connecting to ${this.protocol}${this.ssl ? "s" : ""}://${this.host}:${this.port} ...`
     );
 
     await this.sdk.connect();


### PR DESCRIPTION
## What does this PR do?

The `*:restore` commands where not using the strict mode of `document:mCreate` which can lead to unexpected behavior since errored documents were just silently skipped.  
I also fixed the dumping of errors in a separate file when it's the case.

The `paas:logs` command need to use the `https` module when making HTTPS requests to the PaaS Console

