### PR TITLE
Remove index.history settings forwarding in es:migrate

### DIFF
--- a/src/support/migrate/providers/elasticsearch.ts
+++ b/src/support/migrate/providers/elasticsearch.ts
@@ -35,6 +35,7 @@ export class Elasticsearch implements Provider {
     delete specifications.settings.index.uuid;
     delete specifications.settings.index.version;
     delete specifications.settings.index.routing;
+    delete specifications.settings.index.history;
 
     return specifications;
   }


### PR DESCRIPTION
# Why?
This settings is present on an existing but cannot be given during index creation as a valid setting