### PR TITLE
Disable websocket heartbeat from the SDK when using the debug-proxy

### DIFF
--- a/src/commands/app/debug-proxy.ts
+++ b/src/commands/app/debug-proxy.ts
@@ -57,6 +57,9 @@ export default class DebugProxy extends Kommand {
   };
 
   async runSafe() {
+    // @ts-ignore Disable ping pong since when debugging Kuzzle might not be responding
+    clearInterval(this.sdk.sdk.protocol.pingIntervalId);
+
     const nodeVersionResponse = (await this.sdk.query({
       controller: "debug",
       action: "nodeVersion",


### PR DESCRIPTION
## What does this PR do?

When using the debug-proxy chances are that you may want to take a heap snapshot, taking a heap snapshot freezes the threads of the Kuzzle Node and prevent Kuzzle from responding to the heartbeat request from the SDK.

However while we are taking the snapshot it is important that the connection stays open otherwise Kuzzle will send the resulting snapshot chunks into the void, so to avoid the SDK from disconnecting itself because it did not receive a response from Kuzzle in a certain amount of time, we simply disable the timer responsible for disconnecting the SDK when Kuzzle is not responding.