### PR TITLE
Fix paas:logs errors not displaying

### DIFF
--- a/src/commands/paas/logs.ts
+++ b/src/commands/paas/logs.ts
@@ -124,7 +124,7 @@ class PaasLogs extends PaasKommand {
 
     // Don't continue if an error occurred
     if (incomingMessage.statusCode !== 200) {
-      return new Promise((_, reject) => {
+      return new Promise<void>((_, reject) => {
         // Collect the whole response body
         let responseBody = "";
 

--- a/src/commands/paas/logs.ts
+++ b/src/commands/paas/logs.ts
@@ -122,6 +122,31 @@ class PaasLogs extends PaasKommand {
       until,
     });
 
+    // Don't continue if an error occurred
+    if (incomingMessage.statusCode !== 200) {
+      return new Promise((_, reject) => {
+        // Collect the whole response body
+        let responseBody = "";
+
+        incomingMessage.on("data", (buffer) => {
+          responseBody += buffer.toString();
+        });
+
+        incomingMessage.on("end", () => {
+          let response;
+
+          try {
+            response = JSON.parse(responseBody);
+          } catch (error: any) {
+            reject(new Error("An error occurred while parsing the error response body from Kuzzle"));
+            return;
+          }
+
+          reject(response.error);
+        });
+      });
+    }
+
     // Read the response line by line
     const lineStream = readline.createInterface({
       input: incomingMessage,

--- a/src/support/kuzzle.ts
+++ b/src/support/kuzzle.ts
@@ -219,7 +219,10 @@ export class KuzzleSDK {
     const options = {
       method: "POST",
       headers: {
-        "Authorization": `Bearer ${this.sdk.jwt}`,
+        Accept: "application/json",
+        "Accept-Encoding": "identity",
+        Authorization: `Bearer ${this.sdk.jwt}`,
+        Connection: "keep-alive",
         "Content-Length": Buffer.byteLength(body),
         "Content-Type": "application/json",
       },


### PR DESCRIPTION
## What does this PR do?
This fixes the `kourou paas:logs` command not displaying errors from Kuzzle (e.g. when the status code is different than 200) and exiting silently.