### PR TITLE
Add command for dumping an Elasticsearch instance in the PaaS

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ All other arguments and options will be passed as-is to the `sdk:query` method.
 * [`kourou instance:logs`](#kourou-instancelogs)
 * [`kourou instance:spawn`](#kourou-instancespawn)
 * [`kourou paas:deploy ENVIRONMENT APPLICATIONID IMAGE`](#kourou-paasdeploy-environment-applicationid-image)
+* [`kourou paas:elasticsearch:dump ENVIRONMENT APPLICATIONID DUMPDIRECTORY`](#kourou-paaselasticsearchdump-environment-applicationid-dumpdirectory)
 * [`kourou paas:init PROJECT`](#kourou-paasinit-project)
 * [`kourou paas:login`](#kourou-paaslogin)
 * [`kourou paas:logs ENVIRONMENT APPLICATION`](#kourou-paaslogs-environment-application)
@@ -1056,6 +1057,26 @@ OPTIONS
 ```
 
 _See code: [src/commands/paas/deploy.ts](src/commands/paas/deploy.ts)_
+
+## `kourou paas:elasticsearch:dump ENVIRONMENT APPLICATIONID DUMPDIRECTORY`
+
+Dump data from the Elasticsearch of a PaaS application
+
+```
+USAGE
+  $ kourou paas:elasticsearch:dump ENVIRONMENT APPLICATIONID DUMPDIRECTORY
+
+ARGUMENTS
+  ENVIRONMENT    Project environment name
+  APPLICATIONID  Application Identifier
+  DUMPDIRECTORY  Directory where to store dump files
+
+OPTIONS
+  --help             show CLI help
+  --project=project  Current PaaS project
+```
+
+_See code: [src/commands/paas/elasticsearch/dump.ts](src/commands/paas/elasticsearch/dump.ts)_
 
 ## `kourou paas:init PROJECT`
 

--- a/README.md
+++ b/README.md
@@ -1072,8 +1072,9 @@ ARGUMENTS
   DUMPDIRECTORY  Directory where to store dump files
 
 OPTIONS
-  --help             show CLI help
-  --project=project  Current PaaS project
+  --batch-size=batch-size  [default: 2000] Maximum batch size
+  --help                   show CLI help
+  --project=project        Current PaaS project
 ```
 
 _See code: [src/commands/paas/elasticsearch/dump.ts](src/commands/paas/elasticsearch/dump.ts)_

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "@types/listr": "^0.14.2",
         "@types/mocha": "^8.2.2",
         "@types/ndjson": "^2.0.0",
-        "@types/node": "^14.14.41",
+        "@types/node": "^18.19.0",
         "@types/node-emoji": "^1.8.1",
         "@types/node-fetch": "^2.6.1",
         "@types/tar": "^6.1.3",
@@ -1366,10 +1366,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "14.18.36",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.36.tgz",
-      "integrity": "sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ==",
-      "dev": true
+      "version": "18.19.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.4.tgz",
+      "integrity": "sha512-xNzlUhzoHotIsnFoXmJB+yWmBvFZgKCI9TtPIEdYIMM1KWfwuY8zh7wvc1u1OAXlC7dlf6mZVx/s+Y5KfFz19A==",
+      "dev": true,
+      "dependencies": {
+        "undici-types": "~5.26.4"
+      }
     },
     "node_modules/@types/node-emoji": {
       "version": "1.8.2",
@@ -7668,6 +7671,12 @@
         "node": ">=4.2.0"
       }
     },
+    "node_modules/undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
+      "dev": true
+    },
     "node_modules/universalify": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
@@ -9180,10 +9189,13 @@
       }
     },
     "@types/node": {
-      "version": "14.18.36",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.36.tgz",
-      "integrity": "sha512-FXKWbsJ6a1hIrRxv+FoukuHnGTgEzKYGi7kilfMae96AL9UNkPFNWJEEYWzdRI9ooIkbr4AKldyuSTLql06vLQ==",
-      "dev": true
+      "version": "18.19.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-18.19.4.tgz",
+      "integrity": "sha512-xNzlUhzoHotIsnFoXmJB+yWmBvFZgKCI9TtPIEdYIMM1KWfwuY8zh7wvc1u1OAXlC7dlf6mZVx/s+Y5KfFz19A==",
+      "dev": true,
+      "requires": {
+        "undici-types": "~5.26.4"
+      }
     },
     "@types/node-emoji": {
       "version": "1.8.2",
@@ -13915,6 +13927,12 @@
       "version": "4.4.4",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.4.4.tgz",
       "integrity": "sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==",
+      "dev": true
+    },
+    "undici-types": {
+      "version": "5.26.5",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
+      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
       "dev": true
     },
     "universalify": {

--- a/package.json
+++ b/package.json
@@ -54,7 +54,7 @@
     "@types/listr": "^0.14.2",
     "@types/mocha": "^8.2.2",
     "@types/ndjson": "^2.0.0",
-    "@types/node": "^14.14.41",
+    "@types/node": "^18.19.0",
     "@types/node-emoji": "^1.8.1",
     "@types/node-fetch": "^2.6.1",
     "@types/tar": "^6.1.3",

--- a/src/commands/paas/elasticsearch/dump.ts
+++ b/src/commands/paas/elasticsearch/dump.ts
@@ -26,7 +26,7 @@ type DocumentDumpHit = {
   sort: string[];
 };
 
-class PaasInit extends PaasKommand {
+class PaasEsDump extends PaasKommand {
   public static description = "Dump data from the Elasticsearch of a PaaS application";
 
   public static flags = {
@@ -182,4 +182,4 @@ class PaasInit extends PaasKommand {
   }
 }
 
-export default PaasInit;
+export default PaasEsDump;

--- a/src/commands/paas/elasticsearch/dump.ts
+++ b/src/commands/paas/elasticsearch/dump.ts
@@ -60,6 +60,12 @@ class PaasEsDump extends PaasKommand {
   ];
 
   async runSafe() {
+    // Check that the batch size is positive
+    if (this.flags["batch-size"] <= 0) {
+      this.logKo(`The batch size must be greater than zero. (Specified batch size: ${this.flags["batch-size"]})`);
+      process.exit(1);
+    }
+
     // Log in to the PaaS
     const apiKey = await this.getCredentials();
 

--- a/src/commands/paas/elasticsearch/dump.ts
+++ b/src/commands/paas/elasticsearch/dump.ts
@@ -34,6 +34,10 @@ class PaasEsDump extends PaasKommand {
     project: flags.string({
       description: "Current PaaS project",
     }),
+    "batch-size": flags.integer({
+      description: "Maximum batch size",
+      default: 2000,
+    }),
   };
 
   static args = [
@@ -119,6 +123,7 @@ class PaasEsDump extends PaasKommand {
       body: {
         pitId,
         searchAfter: JSON.stringify(searchAfter),
+        size: this.flags["batch-size"],
       },
     });
 

--- a/src/commands/paas/elasticsearch/dump.ts
+++ b/src/commands/paas/elasticsearch/dump.ts
@@ -1,0 +1,185 @@
+import path from "path";
+import fs from "node:fs/promises";
+
+import { flags } from "@oclif/command";
+
+import { PaasKommand } from "../../../support/PaasKommand";
+
+/**
+  * Results of the document dump action.
+  */
+type DocumentDump = {
+  pit_id: string;
+  hits: DocumentDumpHits;
+};
+
+type DocumentDumpHits = {
+  total: DocumentDumpHitsTotal;
+  hits: DocumentDumpHit[];
+};
+
+type DocumentDumpHitsTotal = {
+  value: number;
+};
+
+type DocumentDumpHit = {
+  sort: string[];
+};
+
+class PaasInit extends PaasKommand {
+  public static description = "Dump data from the Elasticsearch of a PaaS application";
+
+  public static flags = {
+    help: flags.help(),
+    project: flags.string({
+      description: "Current PaaS project",
+    }),
+  };
+
+  static args = [
+    {
+      name: "environment",
+      description: "Project environment name",
+      required: true,
+    },
+    {
+      name: "applicationId",
+      description: "Application Identifier",
+      required: true,
+    },
+    {
+      name: "dumpDirectory",
+      description: "Directory where to store dump files",
+      required: true,
+    }
+  ];
+
+  async runSafe() {
+    // Log in to the PaaS
+    const apiKey = await this.getCredentials();
+
+    await this.initPaasClient({ apiKey });
+
+    const user = await this.paas.auth.getCurrentUser();
+    this.logInfo(
+      `Logged as "${user._id}" for project "${this.flags.project || this.getProject()
+      }"`
+    );
+
+    // Create the dump directory
+    await fs.mkdir(this.args.dumpDirectory, { recursive: true });
+    await fs.mkdir(path.join(this.args.dumpDirectory, "documents/"), { recursive: true });
+
+    // Dump the indexes
+    this.logInfo("Dumping Elasticsearch indexes...");
+
+    const indexesResult = await this.getAllIndexes();
+    await fs.writeFile(path.join(this.args.dumpDirectory, "indexes.json"), JSON.stringify(indexesResult));
+
+    this.logOk("Elasticsearch indexes dumped!");
+
+    // Dump all the documents
+    this.logInfo("Dumping Elasticsearch documents...");
+    await this.dumpAllDocuments();
+
+    this.logOk("Elasticsearch documents dumped!");
+    this.logOk(`The dumped files are available under "${path.resolve(this.args.dumpDirectory)}"`)
+  }
+
+  /**
+    * @description Get all indexes from the Elasticsearch of the PaaS application.
+    * @returns The indexes.
+    */
+  private async getAllIndexes() {
+    const { result }: any = await this.paas.query({
+      controller: "application/storage",
+      action: "getIndexes",
+      environmentId: this.args.environment,
+      projectId: this.flags.project || this.getProject(),
+      applicationId: this.args.applicationId,
+      body: {},
+    });
+
+    return result;
+  }
+
+  /**
+    * @description Dump documents from the Elasticsearch of the PaaS application.
+    * @param pitId ID of the PIT opened on Elasticsearch.
+    * @param searchAfter Cursor for dumping documents after a certain one.
+    * @returns The dumped documents.
+    */
+  private async dumpDocuments(pitId: string, searchAfter: string[]): Promise<DocumentDump> {
+    const { result }: any = await this.paas.query({
+      controller: "application/storage",
+      action: "dumpDocuments",
+      environmentId: this.args.environment,
+      projectId: this.flags.project || this.getProject(),
+      applicationId: this.args.applicationId,
+      body: {
+        pitId,
+        searchAfter: JSON.stringify(searchAfter),
+      },
+    });
+
+    return result;
+  }
+
+  private async dumpAllDocuments() {
+    // Prepare dumping all documents
+    let pitId = "";
+    let searchAfter: string[] = [];
+
+    let currentDocumentChunk = 0;
+    let dumpedDocuments = 0;
+    let totalDocuments = 0;
+
+    // Dump the first batch
+    let result = await this.dumpDocuments(pitId, searchAfter);
+    let hits = result.hits.hits;
+
+    while (hits.length > 0) {
+      // Update the PIT ID and the cursor for the next dump
+      pitId = result.pit_id;
+      searchAfter = hits[hits.length - 1].sort;
+
+      // Save the document
+      await fs.writeFile(path.join(this.args.dumpDirectory, "documents/", `${currentDocumentChunk++}.json`), JSON.stringify(hits));
+
+      dumpedDocuments += hits.length;
+      totalDocuments = result.hits.total.value;
+      this.logInfo(`Dumping Elasticsearch documents: ${Math.floor(dumpedDocuments / totalDocuments * 100)}% (${dumpedDocuments}/${totalDocuments})`);
+
+      // Dump the next batch
+      result = await this.dumpDocuments(pitId, searchAfter);
+      hits = result.hits.hits;
+    }
+
+    // Finish the dump
+    try {
+      await this.finishDump(pitId);
+    } catch (error: any) {
+      this.logInfo("Unable to cleanly finish the dump session:");
+      console.warn(error)
+    }
+  }
+
+  /**
+    * @description Finish the document dumping session.
+    * @param pitId ID of the PIT opened on Elasticsearch.
+    */
+  private async finishDump(pitId: string) {
+    await this.paas.query({
+      controller: "application/storage",
+      action: "finishDumpDocuments",
+      environmentId: this.args.environment,
+      projectId: this.flags.project || this.getProject(),
+      applicationId: this.args.applicationId,
+      body: {
+        pitId,
+      },
+    });
+  }
+}
+
+export default PaasInit;


### PR DESCRIPTION
<!--
  This template is optional.
  It simply serves to provide a guide to allow a better review of pull requests.
-->

<!--
  IMPORTANT
  Don't forget to add the corresponding "changelog:xxx" label to your PR.
  This is part of our release process in order to generate the change log.
-->


## What does this PR do?
This adds the `paas:elasticsearch:dump` command that allows PaaS clients to easily dump the indexes and documents from an Elasticsearch instance of a PaaS application. This PR follows the addition of the `application/storage` controller in the PaaS console.

This command asks for the PaaS environment name and application ID (a project name can also be specified), and a directory where to dump the Elasticsearch data.
The directory structure is automatically created.

First, the indexes are dumped using the `application/storage:getIndexes` action, and are stored in the `<dump_dir>/indexes.json` file.

Then, the documents are dumped usind the `application/storage:dumpDocuments` action, and are stored in the `<dump_dir>/documents.jsonl` file. This file is a [Newline delimited JSON](https://ndjson.org/) file.
Because there could be a huge amount of documents totaling a big size for the response, the PaaS console only allows to dump at most a certain amount of documents at a time. Kourou makes multiple requests to the PaaS console until there are no more documents to dump to get them all. The amount of documents dumped can be set with the `batch-size` flag, but keep in mind that the PaaS console may also limit the maximum amount of documents that can be returned at once.

Finally, the dump session is cleanly terminated and the user is informed where to find their dump files.

![image](https://github.com/kuzzleio/kourou/assets/8174691/08f5e077-069b-4fcb-a845-7cbd0a45e334)

### Other changes

Types for Node.js were updated to Node 18.