### PR TITLE
Allow typescript file to be used by sdk:execute

### DIFF
--- a/features/Sdk.feature
+++ b/features/Sdk.feature
@@ -1,7 +1,5 @@
 Feature: SDK commands
 
-  # sdk:query ==================================================================
-
   @mappings
   Scenario: Send a query to Kuzzle
     Given an existing collection "nyc-open-data":"yellow-taxi"
@@ -21,8 +19,6 @@ Feature: SDK commands
     Then I should match stdout with:
       | "_id": "gordon" |
 
-  # sdk:execute ================================================================
-
   @mappings
   Scenario: Execute code in the SDK context
     Given an existing collection "nyc-open-data":"yellow-taxi"
@@ -30,3 +26,11 @@ Feature: SDK commands
       | arg | return await sdk.document.create("nyc-open-data", "yellow-taxi", {}, "document-adrien"); |
     Then The document "document-adrien" should exist
     And I should match stdout with "document-adrien"
+
+  @mappings
+  Scenario: Execute Typescript code in the SDK context
+    Given an existing collection "nyc-open-data":"yellow-taxi"
+    When I run the command "sdk:execute" with:
+      | arg | return const index: string = "nyc-open-data"; const collection: string = "yellow-taxi"; const id: string = "document-ricky"; await sdk.document.create(index, collection, {}, id); |
+    Then The document "document-ricky" should exist
+    And I should match stdout with "document-ricky"

--- a/features/Sdk.feature
+++ b/features/Sdk.feature
@@ -31,6 +31,6 @@ Feature: SDK commands
   Scenario: Execute Typescript code in the SDK context
     Given an existing collection "nyc-open-data":"yellow-taxi"
     When I run the command "sdk:execute" with:
-      | arg | return const index: string = "nyc-open-data"; const collection: string = "yellow-taxi"; const id: string = "document-ricky"; await sdk.document.create(index, collection, {}, id); |
+      | arg | const index: string = "nyc-open-data"; const collection: string = "yellow-taxi"; const id: string = "document-ricky"; return await sdk.document.create(index, collection, {}, id); |
     Then The document "document-ricky" should exist
     And I should match stdout with "document-ricky"

--- a/src/commands/sdk/execute.ts
+++ b/src/commands/sdk/execute.ts
@@ -131,7 +131,7 @@ ${this.getVariables()}
     let result;
     try {
       // eslint-disable-next-line no-eval
-      result = vm.runInContext(this.code, vm.createContext({}));
+      result = eval(this.code);
     } catch (error: any) {
       userError = error;
     }

--- a/src/commands/sdk/execute.ts
+++ b/src/commands/sdk/execute.ts
@@ -131,7 +131,7 @@ ${this.getVariables()}
     let result;
     try {
       // eslint-disable-next-line no-eval
-      result = eval(this.code);
+      result = await eval(this.code);
     } catch (error: any) {
       userError = error;
     }


### PR DESCRIPTION
<!--
  This template is optional.
  It simply serves to provide a guide to allow a better review of pull requests.
-->

<!--
  IMPORTANT
  Don't forget to add the corresponding "changelog:xxx" label to your PR.
  This is part of our release process in order to generate the change log.
-->


## What does this PR do?
<!-- Please fill this section -->

<!--
  Please include a summary of the change and which issue is fixed.
  Please also include relevant motivation and context.
  List any dependencies that are required for this change.
-->

This PR adds the possibility to use typescript file with the method sdk:execute

### How should this be manually tested?

<!--
  Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce.
  Please also list any relevant details for your test configuration
-->
  - Step 1 : npm run build
  - Step 2 : ./bin/run sdk:execute < some-typescript-file.ts
  - Step 3 :  The code from your ts file is executed
  ...

### Other changes

<!--
  Please describe here all changes not directly linked to the main issue, but made because of it.
  For instance: issues spotted during this PR and fixed on-the-fly, dependencies update, and so on
-->

### Boyscout

<!--
  Describe here minor improvements in the code base and not directly linked to the main changes:
  typos fixes, better/new comments, small code simplification, new debug messages, and so on.
-->
