### PR TITLE
chore: update the generated Compose files

### DIFF
--- a/features/InstanceLogs.feature
+++ b/features/InstanceLogs.feature
@@ -3,4 +3,4 @@ Feature: Instance logs
   Scenario: Show logs of specified kuzzle instance
     When I run the command "instance:logs" with flags:
       | --instance | "kuzzle" |
-    Then I should match stdout with "Kuzzle 2.[0-9]+.[0-9]+ is ready"
+    Then I should match stdout with "Kuzzle 2.[0-9]+.[0-9]+(-\w+.[0-9]+)? is ready"

--- a/features/docker/docker-compose.yml
+++ b/features/docker/docker-compose.yml
@@ -1,5 +1,3 @@
-version: "3.4"
-
 services:
   kuzzle:
     image: kuzzleio/kuzzle:2

--- a/src/commands/app/start-services.ts
+++ b/src/commands/app/start-services.ts
@@ -11,8 +11,6 @@ import { execute } from "../../support/execute";
 import { checkPrerequisites } from "../../support/docker/checkPrerequisites";
 
 const kuzzleServicesFile = `
-version: '3'
-
 services:
   redis:
     image: redis:5

--- a/src/commands/instance/spawn.ts
+++ b/src/commands/instance/spawn.ts
@@ -17,8 +17,6 @@ const MIN_MAX_MAP_COUNT = 262144;
 const MIN_DOCO_VERSION = "2.0.0";
 
 const kuzzleStackV1 = (increment: number): string => `
-version: '3'
-
 services:
   kuzzle:
     image: kuzzleio/kuzzle:1
@@ -53,8 +51,6 @@ services:
 `;
 
 const kuzzleStackV2 = (increment: number): string => `
-version: '3'
-
 services:
   kuzzle:
     image: kuzzleio/kuzzle:2


### PR DESCRIPTION
## What does this PR do?

Compose V1 being [outdated](https://docs.docker.com/compose/compose-file/compose-file-v3/) (and the `docker compose` command starting complaining), this updates the Docker Compose files that are generated by this tool to remove the `version` field ([it is optional and pretty much ignored](https://docs.docker.com/compose/compose-file/04-version-and-name/#version-top-level-element-optional) by Compose anyway).

Nothing else has been modified as our Compose files are already compliant with the current schema.

## Other changes

This fixes one of the tests for a better compatibility with the semver string format.